### PR TITLE
Prefix the extension config options with `ckanext.`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,30 +34,30 @@ Configuration of an LDAP client is always tricky. Unfortunately this really vari
 
 The plugin provides the following **required** configuration items:
 
-- `ldap.uri`: The URI of the LDAP server, of the form _ldap://example.com_. You can use the URI to specify TLS (use 'ldaps' protocol), and the port number (suffix ':port');
-- `ldap.base_dn`: The base dn in which to perform the search. Example: 'ou=USERS,dc=example,dc=com';
-- `ldap.search.filter`: This is the search string that is sent to the LDAP server, in which '{login}' is replaced by the user name provided by the user. Example: 'sAMAccountName={login}'. The search performed here **must** return exactly 0 or 1 entry. See `ldap.search.alt` to provide search on alternate fields;
-- `ldap.username`: The LDAP attribute that will be used as the CKAN username. This **must** be unique;
-- `ldap.email`: The LDAP attribute to map to the user's email address. This **must** be unique.
+- `ckanext.ldap.uri`: The URI of the LDAP server, of the form _ldap://example.com_. You can use the URI to specify TLS (use 'ldaps' protocol), and the port number (suffix ':port');
+- `ckanext.ldap.base_dn`: The base dn in which to perform the search. Example: 'ou=USERS,dc=example,dc=com';
+- `ckanext.ldap.search.filter`: This is the search string that is sent to the LDAP server, in which '{login}' is replaced by the user name provided by the user. Example: 'sAMAccountName={login}'. The search performed here **must** return exactly 0 or 1 entry. See `ckanext.ldap.search.alt` to provide search on alternate fields;
+- `ckanext.ldap.username`: The LDAP attribute that will be used as the CKAN username. This **must** be unique;
+- `ckanext.ldap.email`: The LDAP attribute to map to the user's email address. This **must** be unique.
 
 In addition the plugin provides the following optional configuration items:
 
-- `ldap.ckan_fallback`: If defined and true this will attempt to log in against the CKAN user database when no LDAP user exists;
-- `ldap.prevent_edits`: If defined and true, this will prevent LDAP users from editing their profile. Note that there is no problem in allowing users to change their details - even their user name can be changed. But you may prefer to keep things centralized in your LDAP server. **Important**: while this prevents the operation from happening, it won't actually remove the 'edit settings' button from the dashboard. You need to do this in your own template;
-- `ldap.auth.dn`: If your LDAP server requires authentication (eg. Active Directory), this should be the DN to use;
-- `ldap.auth.password`: If your LDAP server requires authentication, add the password here;
-- `ldap.fullname`: The LDAP attribute to map to the user's full name;
-- `ldap.about`: The LDAP attribute to map to the user's description;
-- `ldap.organization.id`: If this is set, users that log in using LDAP will automatically get added to the given organization. **Warning**: Changing this parameter will only affect users that have not yet logged on. It will not modify the organization of users who have already logged on;
-- `ldap.organization.role`: The role given to users added in the given organization ('admin', 'editor' or 'member'). **Warning**: Changing this parameter will only affect users that have not yet logged on. It will not modify the role of users who have already logged on;
-- `ldap.search.alt`: An alternative search string for the LDAP filter. If this is present and the search using `ldap.search.filter` returns exactly 0 results, then a search using this filter will be performed. If this search returns exactly one result, then it will be accepted. You can use this for example in Active Directory to match against both username and fullname by setting `ldap.search.filter` to  'sAMAccountName={login}' and `ldap.search.alt` to 'name={login}'
-                     The approach of using two separate filter strings (rather than one with an or statement) ensures that priority will always be given to the unique id match. `ldap.search.alt` however can  be used to match against more than one field. For example you could match against either the full name or the email address by setting `ldap.search.alt` to '(|(name={login})(mail={login}))'.
-- `ldap.search.alt_msg`: A message that is output to the user when the search on `ldap.search.filter` returns 0 results, and the search on `ldap.search.alt` returns more than one result. Example: 'Please use your short account name instead'.
+- `ckanext.ldap.ckan_fallback`: If defined and true this will attempt to log in against the CKAN user database when no LDAP user exists;
+- `ckanext.ldap.prevent_edits`: If defined and true, this will prevent LDAP users from editing their profile. Note that there is no problem in allowing users to change their details - even their user name can be changed. But you may prefer to keep things centralized in your LDAP server. **Important**: while this prevents the operation from happening, it won't actually remove the 'edit settings' button from the dashboard. You need to do this in your own template;
+- `ckanext.ldap.auth.dn`: If your LDAP server requires authentication (eg. Active Directory), this should be the DN to use;
+- `ckanext.ldap.auth.password`: If your LDAP server requires authentication, add the password here;
+- `ckanext.ldap.fullname`: The LDAP attribute to map to the user's full name;
+- `ckanext.ldap.about`: The LDAP attribute to map to the user's description;
+- `ckanext.ldap.organization.id`: If this is set, users that log in using LDAP will automatically get added to the given organization. **Warning**: Changing this parameter will only affect users that have not yet logged on. It will not modify the organization of users who have already logged on;
+- `ckanext.ldap.organization.role`: The role given to users added in the given organization ('admin', 'editor' or 'member'). **Warning**: Changing this parameter will only affect users that have not yet logged on. It will not modify the role of users who have already logged on;
+- `ckanext.ldap.search.alt`: An alternative search string for the LDAP filter. If this is present and the search using `ckanext.ldap.search.filter` returns exactly 0 results, then a search using this filter will be performed. If this search returns exactly one result, then it will be accepted. You can use this for example in Active Directory to match against both username and fullname by setting `ckanext.ldap.search.filter` to  'sAMAccountName={login}' and `ckanext.ldap.search.alt` to 'name={login}'
+                     The approach of using two separate filter strings (rather than one with an or statement) ensures that priority will always be given to the unique id match. `ckanext.ldap.search.alt` however can  be used to match against more than one field. For example you could match against either the full name or the email address by setting `ckanext.ldap.search.alt` to '(|(name={login})(mail={login}))'.
+- `ckanext.ldap.search.alt_msg`: A message that is output to the user when the search on `ckanext.ldap.search.filter` returns 0 results, and the search on `ckanext.ldap.search.alt` returns more than one result. Example: 'Please use your short account name instead'.
 
 
 CLI Commands
 ------------
 
-To create the organisation specified in `ldap.organization.id` use the paste command:
+To create the organisation specified in `ckanext.ldap.organization.id` use the paste command:
 
 paster --plugin=ckanext-ldap ldap setup-org -c /etc/ckan/default/development.ini

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ In addition the plugin provides the following optional configuration items:
 - `ckanext.ldap.search.alt_msg`: A message that is output to the user when the search on `ckanext.ldap.search.filter` returns 0 results, and the search on `ckanext.ldap.search.alt` returns more than one result. Example: 'Please use your short account name instead'.
 
 
+**Note**: Configuration options wihtout the `ckanext.` prefix are deprecated and will be eventually removed. Please update your settings if you are using them.
+
+
 CLI Commands
 ------------
 

--- a/ckanext/ldap/commands/ldap.py
+++ b/ckanext/ldap/commands/ldap.py
@@ -46,7 +46,7 @@ class LDAPCommand(CkanCommand):
     def setup_org(self):
 
         # Get the organisation all users will be added to
-        organization_id = pylons.config['ldap.organization.id']
+        organization_id = pylons.config['ckanext.ldap.organization.id']
 
         try:
             toolkit.get_action('organization_show')(self.context, {'id': organization_id})

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -43,12 +43,12 @@ class UserController(p.toolkit.BaseController):
                 # There is an LDAP user, but the auth is wrong. There could be a CKAN user of the
                 # same name if the LDAP user had been created later - in which case we have a
                 # conflict we can't solve.
-                if config['ldap.ckan_fallback']:
+                if config['ckanext.ldap.ckan_fallback']:
                     exists = _ckan_user_exists(login)
                     if exists['exists'] and not exists['is_ldap']:
                         return self._login_failed(error=_('Username conflict. Please contact the site administrator.'))
                 return self._login_failed(error=_('Bad username or password.'))
-            elif config['ldap.ckan_fallback']:
+            elif config['ckanext.ldap.ckan_fallback']:
                 # No LDAP user match, see if we have a CKAN user match
                 try:
                     user_dict = p.toolkit.get_action('user_show')(data_dict = {'id': login})
@@ -165,14 +165,14 @@ def _get_or_create_ldap_user(ldap_user_dict):
     ckan.model.Session.add(ldap_user)
     ckan.model.Session.commit()
     # Add the user to it's group if needed
-    if 'ldap.organization.id' in config:
+    if 'ckanext.ldap.organization.id' in config:
         p.toolkit.get_action('member_create')(
             context={'ignore_auth': True},
             data_dict={
-                'id': config['ldap.organization.id'],
+                'id': config['ckanext.ldap.organization.id'],
                 'object': user_name,
                 'object_type': 'user',
-                'capacity': config['ldap.organization.role']
+                'capacity': config['ckanext.ldap.organization.role']
             }
         )
     return user_name
@@ -187,7 +187,7 @@ def _find_ldap_user(login):
     cnx = ldap.initialize(config['ldap.uri'])
     if config['ldap.auth.dn']:
         try:
-            cnx.bind_s(config['ldap.auth.dn'], config['ldap.auth.password'])
+            cnx.bind_s(config['ckanext.ldap.auth.dn'], config['ckanext.ldap.auth.password'])
         except ldap.SERVER_DOWN:
             log.error('LDAP server is not reachable')
             return None
@@ -195,16 +195,16 @@ def _find_ldap_user(login):
             log.error('LDAP server credentials (ldap.auth.dn and ldap.auth.password) invalid')
             return None
 
-    filter_str = config['ldap.search.filter'].format(login=ldap.filter.escape_filter_chars(login))
-    attributes = [config['ldap.username']]
-    if 'ldap.fullname' in config:
-        attributes.append(config['ldap.fullname'])
-    if 'ldap.email' in config:
-        attributes.append(config['ldap.email'])
+    filter_str = config['ckanext.ldap.search.filter'].format(login=ldap.filter.escape_filter_chars(login))
+    attributes = [config['ckanext.ldap.username']]
+    if 'ckanext.ldap.fullname' in config:
+        attributes.append(config['ckanext.ldap.fullname'])
+    if 'ckanext.ldap.email' in config:
+        attributes.append(config['ckanext.ldap.email'])
     try:
         ret = _ldap_search(cnx, filter_str, attributes, non_unique='log')
-        if ret is None and 'ldap.search.alt' in config:
-            filter_str = config['ldap.search.alt'].format(login=ldap.filter.escape_filter_chars(login))
+        if ret is None and 'ckanext.ldap.search.alt' in config:
+            filter_str = config['ckanext.ldap.search.alt'].format(login=ldap.filter.escape_filter_chars(login))
             ret = _ldap_search(cnx, filter_str, attributes, non_unique='raise')
     finally:
         cnx.unbind()
@@ -226,7 +226,7 @@ def _ldap_search(cnx, filter_str, attributes, non_unique='raise'):
              in attributes; or None if no user was found.
     """
     try:
-        res = cnx.search_s(config['ldap.base_dn'], ldap.SCOPE_SUBTREE, filterstr=filter_str, attrlist=attributes)
+        res = cnx.search_s(config['ckanext.ldap.base_dn'], ldap.SCOPE_SUBTREE, filterstr=filter_str, attrlist=attributes)
     except ldap.SERVER_DOWN:
         log.error('LDAP server is not reachable')
         return None
@@ -243,7 +243,7 @@ def _ldap_search(cnx, filter_str, attributes, non_unique='raise'):
         if non_unique == 'log':
             log.error('LDAP search.filter search returned more than one entry, ignoring. Fix the search to return only 1 or 0 results.')
         elif non_unique == 'raise':
-            raise MultipleMatchError(config['ldap.search.alt_msg'])
+            raise MultipleMatchError(config['ckanext.ldap.search.alt_msg'])
         return None
     elif len(res) == 1:
         cn = res[0][0]
@@ -253,13 +253,13 @@ def _ldap_search(cnx, filter_str, attributes, non_unique='raise'):
         }
         # Check required fields
         for i in ['username', 'email']:
-            cname = 'ldap.' + i
+            cname = 'ckanext.ldap.' + i
             if config[cname] not in attr or not attr[config[cname]]:
                 log.error('LDAP search did not return a {}.'.format(i))
                 return None
         # Set return dict
         for i in ['username', 'fullname', 'email', 'about']:
-            cname = 'ldap.' + i
+            cname = 'ckanext.ldap.' + i
             if cname in config and config[cname] in attr:
                 v = attr[config[cname]]
                 if v:
@@ -276,7 +276,7 @@ def _check_ldap_password(cn, password):
     @param password: Password for cn
     @return: True on success, False on failure
     """
-    cnx = ldap.initialize(config['ldap.uri'])
+    cnx = ldap.initialize(config['ckanext.ldap.uri'])
     try:
         cnx.bind_s(cn, password)
     except ldap.SERVER_DOWN:

--- a/ckanext/ldap/logic/auth/update.py
+++ b/ckanext/ldap/logic/auth/update.py
@@ -14,7 +14,7 @@ def user_update(context, data_dict):
     except ckan.logic.NotFound:
         pass
     # Prevent edition of LDAP users (if so configured)
-    if config['ldap.prevent_edits'] and user_obj and LdapUser.by_user_id(user_obj.id):
+    if config['ckanext.ldap.prevent_edits'] and user_obj and LdapUser.by_user_id(user_obj.id):
         return {'success': False, 'msg': _('Cannot edit LDAP users')}
     # Prevent name clashes!
     if 'name' in data_dict and user_obj and user_obj.name != data_dict['name']:

--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -1,3 +1,4 @@
+import logging
 import pylons
 import ckan.plugins as p
 
@@ -7,6 +8,9 @@ from ckanext.ldap.logic.auth.update import user_update
 from ckanext.ldap.logic.auth.create import user_create
 from ckanext.ldap.model.ldap_user import setup as model_setup
 from ckanext.ldap.lib.helpers import is_ldap_user
+
+
+log = logging.getLogger(__name__)
 
 
 class ConfigError(Exception):
@@ -75,6 +79,8 @@ class LdapPlugin(p.SingletonPlugin):
             if i in main_config:
                 v = main_config[i]
             elif i.replace('ckanext.', '') in main_config:
+                log.warning('LDAP configuration options should be prefixed with \'ckanext.\'. ' +
+                            'Please update {0} to {1}'.format(i.replace('ckanext.', ''), i))
                 # Support ldap.* options for backwards compatibility
                 main_config[i] = main_config[i.replace('ckanext.', '')]
                 v = main_config[i]

--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -54,25 +54,32 @@ class LdapPlugin(p.SingletonPlugin):
         model_setup()
         # Our own config schema, defines required items, default values and transform functions
         schema = {
-            'ldap.uri': {'required': True},
-            'ldap.base_dn': {'required': True},
-            'ldap.search.filter': {'required': True},
-            'ldap.username': {'required': True},
-            'ldap.email': {'required': True},
-            'ldap.auth.dn': {},
-            'ldap.auth.password': {'required_if': 'ldap.auth.dn'},
-            'ldap.search.alt': {},
-            'ldap.search.alt_msg': {'required_if': 'ldap.search.alt'},
-            'ldap.fullname': {},
-            'ldap.organization.id': {},
-            'ldap.organization.role': {'default': 'member', 'validate': _allowed_roles},
-            'ldap.ckan_fallback': {'default': False, 'parse': p.toolkit.asbool},
-            'ldap.prevent_edits': {'default': False, 'parse': p.toolkit.asbool}
+            'ckanext.ldap.uri': {'required': True},
+            'ckanext.ldap.base_dn': {'required': True},
+            'ckanext.ldap.search.filter': {'required': True},
+            'ckanext.ldap.username': {'required': True},
+            'ckanext.ldap.email': {'required': True},
+            'ckanext.ldap.auth.dn': {},
+            'ckanext.ldap.auth.password': {'required_if': 'ckanext.ldap.auth.dn'},
+            'ckanext.ldap.search.alt': {},
+            'ckanext.ldap.search.alt_msg': {'required_if': 'ckanext.ldap.search.alt'},
+            'ckanext.ldap.fullname': {},
+            'ckanext.ldap.organization.id': {},
+            'ckanext.ldap.organization.role': {'default': 'member', 'validate': _allowed_roles},
+            'ckanext.ldap.ckan_fallback': {'default': False, 'parse': p.toolkit.asbool},
+            'ckanext.ldap.prevent_edits': {'default': False, 'parse': p.toolkit.asbool}
         }
         errors = []
         for i in schema:
+            v = None
             if i in main_config:
                 v = main_config[i]
+            elif i.replace('ckanext.', '') in main_config:
+                # Support ldap.* options for backwards compatibility
+                main_config[i] = main_config[i.replace('ckanext.', '')]
+                v = main_config[i]
+
+            if v:
                 if 'parse' in schema[i]:
                     v = (schema[i]['parse'])(v)
                 try:


### PR DESCRIPTION
This may seem a bit OCD but it is a good practice to prefix your config options to avoid clashes with other extensions or external libraries.

The old `ldap.*` options are still fully supported.
