### PR TITLE
Added support for SASL authentication with DIGEST-MD5

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ In addition the plugin provides the following optional configuration items:
 - `ckanext.ldap.prevent_edits`: If defined and true, this will prevent LDAP users from editing their profile. Note that there is no problem in allowing users to change their details - even their user name can be changed. But you may prefer to keep things centralized in your LDAP server. **Important**: while this prevents the operation from happening, it won't actually remove the 'edit settings' button from the dashboard. You need to do this in your own template;
 - `ckanext.ldap.auth.dn`: If your LDAP server requires authentication (eg. Active Directory), this should be the DN to use;
 - `ckanext.ldap.auth.password`: If your LDAP server requires authentication, add the password here;
+- `ckanext.ldap.auth.method`: This is the method of authentication to use, can be either SIMPLE or SASL;
+- `ckanext.ldap.auth.mechanism`: This is the SASL mechanism to use, if auth.method is set to SASL;
 - `ckanext.ldap.fullname`: The LDAP attribute to map to the user's full name;
 - `ckanext.ldap.about`: The LDAP attribute to map to the user's description;
 - `ckanext.ldap.organization.id`: If this is set, users that log in using LDAP will automatically get added to the given organization. **Warning**: Changing this parameter will only affect users that have not yet logged on. It will not modify the organization of users who have already logged on;

--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -65,6 +65,8 @@ class LdapPlugin(p.SingletonPlugin):
             'ckanext.ldap.email': {'required': True},
             'ckanext.ldap.auth.dn': {},
             'ckanext.ldap.auth.password': {'required_if': 'ckanext.ldap.auth.dn'},
+            'ckanext.ldap.auth.method': {'default': 'SIMPLE', 'validate': _allowed_auth_methods},
+            'ckanext.ldap.auth.mechanism': {'default': 'DIGEST-MD5', 'validate': _allowed_auth_mechanisms},
             'ckanext.ldap.search.alt': {},
             'ckanext.ldap.search.alt_msg': {'required_if': 'ckanext.ldap.search.alt'},
             'ckanext.ldap.fullname': {},
@@ -145,3 +147,13 @@ def _allowed_roles(v):
     """Raise an exception if the value is not an allowed role"""
     if v not in ['member', 'editor', 'admin']:
         raise ConfigError('role must be one of "member", "editor" or "admin"')
+
+def _allowed_auth_methods(v):
+    """Raise an exception if the value is not an allowed authentication method"""
+    if v.upper() not in ['SIMPLE', 'SASL']:
+        raise ConfigError('Only SIMPLE and SASL authentication methods are supported')
+
+def _allowed_auth_mechanisms(v):
+    """Raise an exception if the value is not an allowed authentication mechanism"""
+    if v.upper() not in ['DIGEST-MD5',]:  # Only DIGEST-MD5 is supported when the auth method is SASL
+        raise ConfigError('Only DIGEST-MD5 is supported as an authentication mechanism')


### PR DESCRIPTION
In order to use the ckanext-ldap plugin in our Production environment, I had to add support for SASL LDAP authentication.  This is because our Production Active Directory configuration does not allow simple LDAP authentication.  I thought this could be useful for others, and so I added simple settings that open up support for more sophisticated SASL authentication mechanisms if others want to add them.  Let me know if you have any questions, or if this isn't something you feel needs adding to the main repo.  Thanks for making this!
