### PR TITLE
Add manifest so template files are installed via pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+recursive-include ckanext/ldap/templates *

--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,5 @@ setup(
         [paste.paster_command]
             ldap=ckanext.ldap.commands.ldap:LDAPCommand
 	""",
+    include_package_data=True,
 )


### PR DESCRIPTION
This fixes a bug where the extension is not utilised when installed via pip. The root cause being that the login form template is not installed.

Adding a manifest template that specifies that everything under `ckanext/ldap/templates` should be installed solves this problem.
