### PR TITLE
config option to facilitate migrating to LDAP authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This plugin provides LDAP authentication for CKAN. Features include:
 Requirements
 ------------
 
-This plugin uses the pythton-ldap module. This available to install via pip:
+This plugin uses the python-ldap module. This available to install via pip:
 
 ```sh
   pip install python-ldap
@@ -55,9 +55,10 @@ In addition the plugin provides the following optional configuration items:
 - `ckanext.ldap.search.alt`: An alternative search string for the LDAP filter. If this is present and the search using `ckanext.ldap.search.filter` returns exactly 0 results, then a search using this filter will be performed. If this search returns exactly one result, then it will be accepted. You can use this for example in Active Directory to match against both username and fullname by setting `ckanext.ldap.search.filter` to  'sAMAccountName={login}' and `ckanext.ldap.search.alt` to 'name={login}'
                      The approach of using two separate filter strings (rather than one with an or statement) ensures that priority will always be given to the unique id match. `ckanext.ldap.search.alt` however can  be used to match against more than one field. For example you could match against either the full name or the email address by setting `ckanext.ldap.search.alt` to '(|(name={login})(mail={login}))'.
 - `ckanext.ldap.search.alt_msg`: A message that is output to the user when the search on `ckanext.ldap.search.filter` returns 0 results, and the search on `ckanext.ldap.search.alt` returns more than one result. Example: 'Please use your short account name instead'.
+-  `ckanext.ldap.migrate` :  If defined and true this will change an existing CKAN user with the same username to an LDAP user. Otherwise, an exception `UserConflictError`is raised if LDAP-login with an already existing local CKAN username is attempted. This option provides a migration path from local CKAN authentication to LDAP authentication: Rename all users to their LDAP usernames and instruct them to login with their LDAP credentials. Migration then happens transparently.
 
 
-**Note**: Configuration options wihtout the `ckanext.` prefix are deprecated and will be eventually removed. Please update your settings if you are using them.
+**Note**: Configuration options without the `ckanext.` prefix are deprecated and will be eventually removed. Please update your settings if you are using them.
 
 
 CLI Commands

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -137,9 +137,9 @@ def _get_or_create_ldap_user(ldap_user_dict):
     if ldap_user:
         # TODO: Update the user detail.
         return ldap_user.user.name
-    # Check whether we have a name conflict (based on the ldap name, without mapping it to allowed chars)
     user_dict = {}
     update=False
+    # Check whether we have a name conflict (based on the ldap name, without mapping it to allowed chars)
     exists = _ckan_user_exists(ldap_user_dict['username'])
     if exists['exists'] and not exists['is_ldap']:
         # If ckanext.ldap.migrate is set, update exsting user_dict.

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -138,29 +138,43 @@ def _get_or_create_ldap_user(ldap_user_dict):
         # TODO: Update the user detail.
         return ldap_user.user.name
     # Check whether we have a name conflict (based on the ldap name, without mapping it to allowed chars)
+    user_dict = {}
+    update=False
     exists = _ckan_user_exists(ldap_user_dict['username'])
     if exists['exists'] and not exists['is_ldap']:
-        raise UserConflictError(_('There is a username conflict. Please inform the site administrator.'))
+        # If ckanext.ldap.migrate is set, update exsting user_dict.
+        if not config['ckanext.ldap.migrate']:
+             raise UserConflictError(_('There is a username conflict. Please inform the site administrator.'))
+        else:
+            user_dict = p.toolkit.get_action('user_show')(data_dict = {'id': ldap_user_dict['username']})
+            update=True
+        
     # If a user with the same ckan name already exists but is an LDAP user, this means (given that we didn't
     # find it above) that the conflict arises from having mangled another user's LDAP name. There will not
     # however be a conflict based on what is entered in the user prompt - so we can go ahead. The current
     # user's id will just be mangled to something different.
 
-    # Now get a unique user name, and create the CKAN user and the LdapUser entry.
-    user_name = _get_unique_user_name(ldap_user_dict['username'])
-    user_dict = {
+    # Now get a unique user name (if not "migrating"), and create the CKAN user and the LdapUser entry.
+    user_name = user_dict['name'] if update else _get_unique_user_name(ldap_user_dict['username'])
+    user_dict.update({
         'name': user_name,
         'email': ldap_user_dict['email'],
         'password': str(uuid.uuid4())
-    }
+    })
     if 'fullname' in ldap_user_dict:
         user_dict['fullname'] = ldap_user_dict['fullname']
     if 'about' in ldap_user_dict:
         user_dict['about'] = ldap_user_dict['about']
-    ckan_user = p.toolkit.get_action('user_create')(
-        context={'ignore_auth': True},
-        data_dict=user_dict
-    )
+    if update:
+        ckan_user = p.toolkit.get_action('user_update')(
+            context={'ignore_auth': True},
+            data_dict=user_dict
+        )
+    else:
+        ckan_user = p.toolkit.get_action('user_create')(
+            context={'ignore_auth': True},
+            data_dict=user_dict
+        )
     ldap_user = LdapUser(user_id=ckan_user['id'], ldap_id = ldap_user_dict['username'])
     ckan.model.Session.add(ldap_user)
     ckan.model.Session.commit()

--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -73,7 +73,8 @@ class LdapPlugin(p.SingletonPlugin):
             'ckanext.ldap.organization.id': {},
             'ckanext.ldap.organization.role': {'default': 'member', 'validate': _allowed_roles},
             'ckanext.ldap.ckan_fallback': {'default': False, 'parse': p.toolkit.asbool},
-            'ckanext.ldap.prevent_edits': {'default': False, 'parse': p.toolkit.asbool}
+            'ckanext.ldap.prevent_edits': {'default': False, 'parse': p.toolkit.asbool},
+            'ckanext.ldap.migrate': {'default': False, 'parse': p.toolkit.asbool}
         }
         errors = []
         for i in schema:


### PR DESCRIPTION
If attempting to login with valid LDAP-credentials but with username for which a local, non-LDAP CKAN account already exists, an exception `UserConflictError` is raised. That is generally sensible behavior. However, it can be useful to change that if one wants to migrate a userbase from local accounts to LDAP accounts:

Here is a patch that provides the config-option `ckanext.ldap.migrate` :
If defined and true this will change an existing CKAN user with the same username to an LDAP user. This option provides a migration path from local CKAN authentication to LDAP authentication: Rename all users to their LDAP usernames and instruct them to login with their LDAP credentials. Migration then happens transparently.