### PR TITLE
nicodeEncodeError: 'ascii' codec can't encode characters in position 0-6: ordinal not in range(128)

### DIFF
--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -307,7 +307,7 @@ def _check_ldap_password(cn, password):
     """
     cnx = ldap.initialize(config['ckanext.ldap.uri'])
     try:
-        cnx.bind_s(cn, ldap.filter.escape_filter_chars(password))
+        cnx.bind_s(utf8_encode(cn), utf8_encode(password))
     except ldap.SERVER_DOWN:
         log.error('LDAP server is not reachable')
         return False

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -307,7 +307,7 @@ def _check_ldap_password(cn, password):
     """
     cnx = ldap.initialize(config['ckanext.ldap.uri'])
     try:
-        cnx.bind_s(cn, password)
+        cnx.bind_s(cn, ldap.filter.escape_filter_chars(password))
     except ldap.SERVER_DOWN:
         log.error('LDAP server is not reachable')
         return False


### PR DESCRIPTION
Hi everyone, 

we had troubles when a username or password contains the speical char § which leads to following error message: UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-6: ordinal not in range(128)

The following pull fixes that be encoding the username and password to utf-8

Jakob