### PR TITLE
Fix unicode issue

### DIFF
--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -292,7 +292,7 @@ def _ldap_search(cnx, filter_str, attributes, non_unique='raise'):
             if cname in config and config[cname] in attr:
                 v = attr[config[cname]]
                 if v:
-                    ret[i] = v[0]
+                    ret[i] = _decode_utf8(v[0])
         return ret
     else:
         return None
@@ -320,3 +320,11 @@ def _check_ldap_password(cn, password):
         return False
     cnx.unbind_s()
     return True
+
+
+def _decode_utf8(s, encoding='utf-8'):
+    """ Converts str to unicode """
+    if isinstance(s, str):
+        return(unicode(s, encoding))
+    else:
+        return s

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -314,5 +314,8 @@ def _check_ldap_password(cn, password):
     except ldap.INVALID_CREDENTIALS:
         log.debug('Invalid LDAP credentials')
         return False
+    if password == '':
+        log.debug('Invalid LDAP credentials')
+        return False
     cnx.unbind_s()
     return True


### PR DESCRIPTION
LDAP entries might well contain non-ASCII characters. LDAP should return them UTF-8 encoded. If they stay that way there is trouble further down, when CKAN core tries to decode them with the standard encoding (=ASCII):
`UnicodeDecodeError: 'ascii' codec can't decode byte 0xe4 in position 0: ordinal not in range(128)`

This PR converts all `str` coming from reading LDAP records to `unicode` (assuming it's UTF-8 encoded). This is in line with CKAN guidelines (http://docs.ckan.org/en/latest/contributing/unicode.html#overall-strategy).