### PR TITLE
Upgrade ldap dependency to support unicode

### DIFF
--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -1,6 +1,7 @@
 import re
 import uuid
 import logging
+import sys
 import ldap, ldap.filter
 import ckan.plugins as p
 import ckan.model
@@ -323,8 +324,11 @@ def _check_ldap_password(cn, password):
 
 
 def _decode_str(s, encoding='utf-8'):
-    """ Converts str to unicode """
-    if isinstance(s, str):
-        return unicode(s, encoding)
-    else:
-        return s
+    try:
+        # this try throws NameError if this is python3
+        if isinstance(s, basestring) and isinstance(s, str):
+            return unicode(s, encoding)
+    except NameError:
+        if isinstance (s, bytes):
+            return s.decode(encoding)
+    return s

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -292,7 +292,7 @@ def _ldap_search(cnx, filter_str, attributes, non_unique='raise'):
             if cname in config and config[cname] in attr:
                 v = attr[config[cname]]
                 if v:
-                    ret[i] = v[0]
+                    ret[i] = _decode_str(v[0])
         return ret
     else:
         return None
@@ -320,3 +320,11 @@ def _check_ldap_password(cn, password):
         return False
     cnx.unbind_s()
     return True
+
+
+def _decode_str(s, encoding='utf-8'):
+    """ Converts str to unicode """
+    if isinstance(s, str):
+        return unicode(s, encoding)
+    else:
+        return s

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -198,7 +198,7 @@ def _find_ldap_user(login):
     @param login: The login to find in the LDAP database
     @return: None if no user is found, a dictionary defining 'cn', 'username', 'fullname' and 'email otherwise.
     """
-    cnx = ldap.initialize(config['ckanext.ldap.uri'])
+    cnx = ldap.initialize(config['ckanext.ldap.uri'], bytes_mode=False)
     if config.get('ckanext.ldap.auth.dn'):
         try:
             if config['ckanext.ldap.auth.method'] == 'SIMPLE':
@@ -305,7 +305,7 @@ def _check_ldap_password(cn, password):
     @param password: Password for cn
     @return: True on success, False on failure
     """
-    cnx = ldap.initialize(config['ckanext.ldap.uri'])
+    cnx = ldap.initialize(config['ckanext.ldap.uri'], bytes_mode=False)
     try:
         cnx.bind_s(cn, password)
     except ldap.SERVER_DOWN:

--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -106,6 +106,10 @@ class LdapPlugin(p.SingletonPlugin):
                 config[i] = schema[i]['default']
         if len(errors):
             raise ConfigError("\n".join(errors))
+        # make sure all the strings in the config are unicode formatted
+        for key, value in config.iteritems():
+            if isinstance(value, str):
+                config[key] = unicode(value, encoding='utf-8')
 
     def login(self):
         """Implementation of IAuthenticator.login

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-ldap
+python-ldap==3.0.0b2


### PR DESCRIPTION
`python-ldap` 2.5.2 which we are currently using doesn't support unicode characters at all and therefore any attempts to login with a unicode username or password result in a server error. This PR upgrades to the latest version (3.0.0b2) and then uses it's new capabilities to ensure we support unicode.

H/T: https://github.com/NaturalHistoryMuseum/ckanext-ldap/pull/21