### PR TITLE
Upgrade python-ldap requirement to 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-ldap==3.0.0b2
+python-ldap==3.0.0


### PR DESCRIPTION
The extension could not be run under Alpine Linux due to this exception:

	  File "/usr/lib/python2.7/site-packages/ldap/__init__.py", line 22, in <module>
	    import _ldap
	ImportError: Error relocating /usr/lib/python2.7/site-packages/_ldap.so: ber_free: symbol not found

The latest version (3.0.0) includes the [fix](https://github.com/python-ldap/python-ldap/pull/173/files) for this. Plus it's nice to target a stable version instead of a beta one.