### PR TITLE
Ignore auth when calling user_show

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-ldap==3.0.0b2
+python-ldap==3.0.0


### PR DESCRIPTION
The default authorization for user_show allows anyone to access user details, but if this has been restricted on a particular site, the calls in the controller will fail with a `NotAuthorized` error.

This change just passes `ignore_auth=True` to `user_show` calls and refactors it a bit.