### PR TITLE
Honor URL-parameter "came_from "

### DIFF
--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -23,12 +23,11 @@ class UserConflictError(Exception):
 
 
 class UserController(p.toolkit.BaseController):
-
     def __init__(self):
         ldap.set_option(ldap.OPT_DEBUG_LEVEL, config['ckanext.ldap.debug_level'])
-
     def login_handler(self):
         """Action called when login in via the LDAP login form"""
+        came_from = request.params['came_from']
         params = request.POST
         if 'login' in params and 'password' in params:
             login = params['login']
@@ -43,7 +42,7 @@ class UserController(p.toolkit.BaseController):
                     user_name = _get_or_create_ldap_user(ldap_user_dict)
                 except UserConflictError as e:
                     return self._login_failed(error=str(e))
-                return self._login_success(user_name)
+                return self._login_success(user_name, came_from=came_from)
             elif ldap_user_dict:
                 # There is an LDAP user, but the auth is wrong. There could be a CKAN user of the
                 # same name if the LDAP user had been created later - in which case we have a
@@ -83,7 +82,7 @@ class UserController(p.toolkit.BaseController):
             flash_error(error)
         p.toolkit.redirect_to(controller='user', action='login')
 
-    def _login_success(self, user_name):
+    def _login_success(self, user_name, came_from="/dataset"):
         """Handle login success
 
         Saves the user in the session and redirects to user/logged_in
@@ -92,9 +91,7 @@ class UserController(p.toolkit.BaseController):
         """
         pylons.session['ckanext-ldap-user'] = user_name
         pylons.session.save()
-        p.toolkit.redirect_to(controller='user', action='dashboard', id=user_name)
-
-
+        p.toolkit.redirect_to(controller='user', action='logged_in', came_from=came_from)
 def _get_user_dict(user_id):
     """Calls the action API to get the detail for a user given their id
 
@@ -112,7 +109,6 @@ def _ckan_user_exists(user_name):
     @return: Dictionary defining 'exists' and 'ldap'.
     """
     try:
-
         user = _get_user_dict(user_name)
     except p.toolkit.ObjectNotFound:
         return {'exists': False, 'is_ldap': False}
@@ -164,7 +160,7 @@ def _get_or_create_ldap_user(ldap_user_dict):
         else:
             user_dict = _get_user_dict(ldap_user_dict['username'])
             update=True
-
+        
     # If a user with the same ckan name already exists but is an LDAP user, this means (given that we didn't
     # find it above) that the conflict arises from having mangled another user's LDAP name. There will not
     # however be a conflict based on what is entered in the user prompt - so we can go ahead. The current
@@ -338,8 +334,6 @@ def _check_ldap_password(cn, password):
         return False
     cnx.unbind_s()
     return True
-
-
 def _decode_str(s, encoding='utf-8'):
     try:
         # this try throws NameError if this is python3

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -27,7 +27,7 @@ class UserController(p.toolkit.BaseController):
         ldap.set_option(ldap.OPT_DEBUG_LEVEL, config['ckanext.ldap.debug_level'])
     def login_handler(self):
         """Action called when login in via the LDAP login form"""
-        came_from = request.params['came_from']
+        came_from = request.params.get('came_from', '')
         params = request.POST
         if 'login' in params and 'password' in params:
             login = params['login']
@@ -61,7 +61,7 @@ class UserController(p.toolkit.BaseController):
                 except p.toolkit.ObjectNotFound:
                     user = None
                 if user and user.validate_password(password):
-                    return self._login_success(user.name)
+                    return self._login_success(user.name, came_from=came_from)
                 else:
                     return self._login_failed(error=_('Bad username or password.'))
             else:
@@ -82,7 +82,7 @@ class UserController(p.toolkit.BaseController):
             flash_error(error)
         p.toolkit.redirect_to(controller='user', action='login')
 
-    def _login_success(self, user_name, came_from="/dataset"):
+    def _login_success(self, user_name, came_from):
         """Handle login success
 
         Saves the user in the session and redirects to user/logged_in
@@ -92,6 +92,7 @@ class UserController(p.toolkit.BaseController):
         pylons.session['ckanext-ldap-user'] = user_name
         pylons.session.save()
         p.toolkit.redirect_to(controller='user', action='logged_in', came_from=came_from)
+        
 def _get_user_dict(user_id):
     """Calls the action API to get the detail for a user given their id
 

--- a/ckanext/ldap/lib/helpers.py
+++ b/ckanext/ldap/lib/helpers.py
@@ -7,7 +7,7 @@ Amended: hvw / 2018
 """
 
 import pylons
-from ckan.plugins.toolkit import c
+from ckan.plugins import toolkit
 
 try:
     # In case we are running Python3
@@ -30,7 +30,7 @@ def get_login_action():
     as stored in context object's login_handler.
 
     '''
-    lh = c.login_handler
+    lh = toolkit.c.login_handler
     camefrom = parse_qs(urlparse(lh).query).get('came_from')
     if camefrom:
         action = "/ldap_login_handler?came_from=" + camefrom[0]

--- a/ckanext/ldap/lib/helpers.py
+++ b/ckanext/ldap/lib/helpers.py
@@ -3,9 +3,17 @@
 """
 Created by 'bens3' on 2013-06-21.
 Copyright (c) 2013 'bens3'. All rights reserved.
+Amended: hvw / 2018
 """
 
 import pylons
+from ckan.plugins.toolkit import c
+
+try:
+    # In case we are running Python3
+    from urllib.parse import urlparse, parse_qs
+except ImportError:
+    from urlparse import urlparse, parse_qs
 
 
 def is_ldap_user():
@@ -15,3 +23,17 @@ def is_ldap_user():
     """
 
     return 'ckanext-ldap-user' in pylons.session
+
+
+def get_login_action():
+    ''' Returns ldap login handler. Preserves parameter `came_from`
+    as stored in context object's login_handler.
+
+    '''
+    lh = c.login_handler
+    camefrom = parse_qs(urlparse(lh).query).get('came_from')
+    if camefrom:
+        action = "/ldap_login_handler?came_from=" + camefrom[0]
+    else:
+        action = "/ldap_login_handler"
+    return action 

--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -7,7 +7,7 @@ config = {}
 from ckanext.ldap.logic.auth.update import user_update
 from ckanext.ldap.logic.auth.create import user_create
 from ckanext.ldap.model.ldap_user import setup as model_setup
-from ckanext.ldap.lib.helpers import is_ldap_user
+from ckanext.ldap.lib.helpers import is_ldap_user, get_login_action
 
 
 log = logging.getLogger(__name__)
@@ -146,7 +146,8 @@ class LdapPlugin(p.SingletonPlugin):
 
     def get_helpers(self):
         return {
-            'is_ldap_user': is_ldap_user
+            'is_ldap_user': is_ldap_user,
+            'get_login_action': get_login_action
         }
 
 

--- a/ckanext/ldap/templates/user/login.html
+++ b/ckanext/ldap/templates/user/login.html
@@ -1,8 +1,6 @@
 {% ckan_extends %}
 
-{% set camefrom = c.login_handler.split("?")[1] | default("came_from=/dataset") %} 
-{% set camefrom = camefrom.split("=")[1] %}
-{% set action = "/ldap_login_handler?came_from="+camefrom %}
+{% set action = h.get_login_action() %}
 {% block form %}
   {% snippet "user/snippets/login_form.html", action=action, error_summary=error_summary %}
 {% endblock %}

--- a/ckanext/ldap/templates/user/login.html
+++ b/ckanext/ldap/templates/user/login.html
@@ -1,5 +1,8 @@
 {% ckan_extends %}
 
+{% set camefrom = c.login_handler.split("?")[1] | default("came_from=/dataset") %} 
+{% set camefrom = camefrom.split("=")[1] %}
+{% set action = "/ldap_login_handler?came_from="+camefrom %}
 {% block form %}
-  {% snippet "user/snippets/login_form.html", action="/ldap_login_handler", error_summary=error_summary %}
+  {% snippet "user/snippets/login_form.html", action=action, error_summary=error_summary %}
 {% endblock %}


### PR DESCRIPTION
So far the URL parameter `came_from` is ignored by `ckanext-ldap` and users, after logging in, always end up at their dashboard. This PR fixes this. `came_from` can be used to redirect, after login, to the page the user came from, which required logging in.

Flow of info is a bit convoluted though:   
Core login module saves this parameter as part of an URL in `pylons.c`. From there it is recovered in `ldap/templates/user/login.html` and handed to `ckan/templates/user/snippets/login_form.html` which calls` ldap_login_handler` with the proper parameter. The parameter is then handed through to `ldap/controllers/user.UserController:_login_success`, where redirection to the dashboard is replaced with `ckan/controllers/user.UserController:logged_in/came_from`.