### PR TITLE
Rename `action` variable in /user/login.html

### DIFF
--- a/ckanext/ldap/templates/user/login.html
+++ b/ckanext/ldap/templates/user/login.html
@@ -1,6 +1,6 @@
 {% ckan_extends %}
 
-{% set action = h.get_login_action() %}
+{% set ldap_action = h.get_login_action() %}
 {% block form %}
-  {% snippet "user/snippets/login_form.html", action=action, error_summary=error_summary %}
+  {% snippet "user/snippets/login_form.html", action=ldap_action, error_summary=error_summary %}
 {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/NaturalHistoryMuseum/ckanext-ldap/issues/36

For some reason, setting a variable named `action` in this location causes the variable to be set to `""`.
See Issue: https://github.com/NaturalHistoryMuseum/ckanext-ldap/issues/36
I think it is a scoping thing. Perhaps there is another variable named "action" somewhere in the template hierarchy that is set to `""` and overrides this one.

Renaming the variable fixes the problem.

I don't believe this variable is used anywhere else, so renaming it here shouldn't cause any other problems to crop up.