### PR TITLE
Ckan upgrade 2.8.0a - permit alternative DistinguishedName (dn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Configuration of an LDAP client is always tricky. Unfortunately this really vari
 The plugin provides the following **required** configuration items:
 
 - `ckanext.ldap.uri`: The URI of the LDAP server, of the form _ldap://example.com_. You can use the URI to specify TLS (use 'ldaps' protocol), and the port number (suffix ':port');
-- `ckanext.ldap.base_dn`: The base dn in which to perform the search. Example: 'ou=USERS,dc=example,dc=com';
+- `ckanext.ldap.base_dn`: The base Dinstinguished Name (DN) in which to perform the search. Example: 'ou=USERS,dc=example,dc=com';
+- `ckanext.ldap.base_dn_alt`: The alternative DN in case you have to look in more than one Organizational Unit (OU). This item is optional, use only if needed. Example: 'ou="Other OU",dc=example,dc=com'; 
 - `ckanext.ldap.search.filter`: This is the search string that is sent to the LDAP server, in which '{login}' is replaced by the user name provided by the user. Example: 'sAMAccountName={login}'. The search performed here **must** return exactly 0 or 1 entry. See `ckanext.ldap.search.alt` to provide search on alternate fields;
 - `ckanext.ldap.username`: The LDAP attribute that will be used as the CKAN username. This **must** be unique;
 - `ckanext.ldap.email`: The LDAP attribute to map to the user's email address. This **must** be unique.

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -287,6 +287,8 @@ def _find_ldap_user(login):
 
     filter_str = config[u'ckanext.ldap.search.filter'].format(
         login=ldap.filter.escape_filter_chars(login))
+    filter_str_alt = config[u'ckanext.ldap.search.alt'].format(
+        login=ldap.filter.escape_filter_chars(login))
     attributes = [config[u'ckanext.ldap.username']]
     if u'ckanext.ldap.fullname' in config:
         attributes.append(config[u'ckanext.ldap.fullname'])
@@ -296,15 +298,11 @@ def _find_ldap_user(login):
     try:
         ret = _ldap_search(cnx, filter_str, attributes, config[u'ckanext.ldap.base_dn'], non_unique=u'log')
         if ret is None and u'ckanext.ldap.search.alt' in config:
-            filter_str = config[u'ckanext.ldap.search.alt'].format(
-                login=ldap.filter.escape_filter_chars(login))
-            ret = _ldap_search(cnx, filter_str, attributes, config[u'ckanext.ldap.base_dn'], non_unique=u'raise')
-            if ret is None and u'ckanext.ldap.base_dn_alt' in config:
-                filter_str = config[u'ckanext.ldap.search.filter'].format(
-                login=ldap.filter.escape_filter_chars(login))
-                ret = _ldap_search(cnx, filter_str, attributes, config[u'ckanext.ldap.base_dn_alt'], non_unique=u'raise')
-        elif ret is None and u'ckanext.ldap.base_dn_alt' in config:
-            ret = _ldap_search(cnx, filter_str, attributes, config[u'ckanext.ldap.base_dn_alt'], non_unique=u'log')
+            ret = _ldap_search(cnx, filter_str_alt, attributes, config[u'ckanext.ldap.base_dn'], non_unique=u'raise')
+        if ret is None and u'ckanext.ldap.base_dn_alt' in config:
+            ret = _ldap_search(cnx, filter_str, attributes, config[u'ckanext.ldap.base_dn_alt'], non_unique=u'log
+        if ret is None and u'ckanext.ldap.base_dn_alt' in config and u'ckanext.ldap.search.alt' in config:
+            ret = _ldap_search(cnx, filter_str_alt, attributes, config[u'ckanext.ldap.base_dn_alt'], non_unique=u'raise
 
     finally:
         cnx.unbind()
@@ -331,8 +329,7 @@ def _ldap_search(cnx, filter_str, attributes, base_dn_str, non_unique=u'raise'):
     try:
         res = cnx.search_s(base_dn_str, ldap.SCOPE_SUBTREE,
                            filterstr=filter_str, attrlist=attributes)
-        '''res = cnx.search_s(None, ldap.SCOPE_SUBTREE, filterstr=filter_str, attrlist=attributes)
-        '''
+
     except ldap.SERVER_DOWN:
         log.error(u'LDAP server is not reachable')
         return None

--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -86,6 +86,9 @@ class LdapPlugin(SingletonPlugin):
             u'ckanext.ldap.base_dn': {
                 u'required': True
                 },
+            u'ckanext.ldap.base_dn_alt': { 
+                u'required': False
+                },
             u'ckanext.ldap.search.filter': {
                 u'required': True
                 },


### PR DESCRIPTION
Includes a new parameter, called **ckanext.ldap.base_dn_alt** with permits a new Distinguished Name to be searched when a login operation is performed. 
It uses the same logic implemented in the parameter ckanext.ldap.search_alt that already existed.
This was implemented because the forest of my organization has two organizational units (OU) and the CKAN must be acessed from users from both OUs.