### PR TITLE
Added the ability to choose the first account returned if multiple accounts are found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.7"
+# command to install dependencies
+install:
+  - "pip install -e ."
+  - "pip install -r requirements.txt"
+  - "pip install -r dev_requirements.txt"
+# command to run tests
+script: coverage run --source=ckanext.ldap setup.py nosetests
+after_success: coveralls

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In addition the plugin provides the following optional configuration items:
 - `ckanext.ldap.migrate` :  If defined and true this will change an existing CKAN user with the same username to an LDAP user. Otherwise, an exception `UserConflictError`is raised if LDAP-login with an already existing local CKAN username is attempted. This option provides a migration path from local CKAN authentication to LDAP authentication: Rename all users to their LDAP usernames and instruct them to login with their LDAP credentials. Migration then happens transparently.
 - `ckanext.ldap.debug_level`: Default value 0 (no logging). [More information](https://www.python-ldap.org/en/python-ldap-3.0.0b1/reference/ldap.html?highlight=debug_level#ldap.OPT_DEBUG_LEVEL).
 - `ckanext.ldap.trace_level`: Default value 0 (no logging). [More information](https://www.python-ldap.org/en/python-ldap-3.0.0b1/reference/ldap.html?highlight=trace_level#ldap.initialize).
-
+- `ckanext.ldap.use_first`: Override the `ckanext.ldap.search.filter` to accept the first record if multiple records are returned.
 
 **Note**: Configuration options without the `ckanext.` prefix are deprecated and will be eventually removed. Please update your settings if you are using them.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ckanext-ldap
 ============
 
+[![Travis branch](https://img.shields.io/travis/NaturalHistoryMuseum/ckanext-ldap/master.svg?style=flat-square)](https://travis-ci.org/NaturalHistoryMuseum/ckanext-ldap) [![Coveralls github branch](https://img.shields.io/coveralls/github/NaturalHistoryMuseum/ckanext-ldap/master.svg?style=flat-square)](https://coveralls.io/github/NaturalHistoryMuseum/ckanext-ldap)
+
 Overview
 --------
 

--- a/ckanext/__init__.py
+++ b/ckanext/__init__.py
@@ -1,4 +1,9 @@
-# this is a namespace package
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# This file is part of ckanext-ldap
+# Created by the Natural History Museum in London, UK
+
 try:
     import pkg_resources
     pkg_resources.declare_namespace(__name__)

--- a/ckanext/ldap/__init__.py
+++ b/ckanext/ldap/__init__.py
@@ -1,4 +1,9 @@
-# this is a namespace package
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# This file is part of ckanext-ldap
+# Created by the Natural History Museum in London, UK
+
 try:
     import pkg_resources
     pkg_resources.declare_namespace(__name__)

--- a/ckanext/ldap/commands/__init__.py
+++ b/ckanext/ldap/commands/__init__.py
@@ -1,12 +1,8 @@
-
-#!/usr/bin/env python
+# !/usr/bin/env python
 # encoding: utf-8
 #
 # This file is part of ckanext-ldap
 # Created by the Natural History Museum in London, UK
-
-import sys
-import os
 
 
 def main():
@@ -16,5 +12,3 @@ def main():
 
 if __name__ == u'__main__':
     main()
-
-

--- a/ckanext/ldap/commands/__init__.py
+++ b/ckanext/ldap/commands/__init__.py
@@ -1,18 +1,20 @@
+
 #!/usr/bin/env python
 # encoding: utf-8
-"""
-Created by 'bens3' on 2013-06-21.
-Copyright (c) 2013 'bens3'. All rights reserved.
-"""
+#
+# This file is part of ckanext-ldap
+# Created by the Natural History Museum in London, UK
 
 import sys
 import os
 
 
 def main():
+    ''' '''
     pass
 
 
-if __name__ == '__main__':
+if __name__ == u'__main__':
     main()
+
 

--- a/ckanext/ldap/commands/ldap.py
+++ b/ckanext/ldap/commands/ldap.py
@@ -6,28 +6,25 @@
 
 
 import logging
-import pylons
-from ckan.lib.cli import CkanCommand
-from ckanext.datastore.db import _get_engine
+
 from ckan.plugins import toolkit
-from ckan import logic
 
 log = logging.getLogger()
 
-class LDAPCommand(CkanCommand):
+
+class LDAPCommand(toolkit.CkanCommand):
     '''Paster function to set up the default organisation
     
-    Paster function can be included to provision scripts - otherwise, get an error after provisioning new CKAN instance
+    Paster function can be included to provision scripts - otherwise, get an error after
+    provisioning new CKAN instance
     
     Commands:
     
         paster ldap setup-org -c /etc/ckan/default/development.ini
 
-
     '''
     summary = __doc__.split(u'\n')[0]
     usage = __doc__
-
 
     def command(self):
         ''' '''
@@ -39,8 +36,12 @@ class LDAPCommand(CkanCommand):
         self._load_config()
 
         # Set up context
-        user = toolkit.get_action(u'get_site_user')({u'ignore_auth': True}, {})
-        self.context = {u'user': user[u'name']}
+        user = toolkit.get_action(u'get_site_user')({
+            u'ignore_auth': True
+            }, {})
+        self.context = {
+            u'user': user[u'name']
+            }
 
         cmd = self.args[0]
 
@@ -53,9 +54,14 @@ class LDAPCommand(CkanCommand):
         ''' '''
 
         # Get the organisation all users will be added to
-        organization_id = pylons.config[u'ckanext.ldap.organization.id']
+        organization_id = toolkit.config[u'ckanext.ldap.organization.id']
 
         try:
-            toolkit.get_action(u'organization_show')(self.context, {u'id': organization_id})
-        except logic.NotFound:
-            toolkit.get_action(u'organization_create')(self.context, {u'id': organization_id, u'name': organization_id})
+            toolkit.get_action(u'organization_show')(self.context, {
+                u'id': organization_id
+                })
+        except toolkit.ObjectNotFound:
+            toolkit.get_action(u'organization_create')(self.context, {
+                u'id': organization_id,
+                u'name': organization_id
+                })

--- a/ckanext/ldap/commands/ldap.py
+++ b/ckanext/ldap/commands/ldap.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# This file is part of ckanext-ldap
+# Created by the Natural History Museum in London, UK
+
 
 import logging
 import pylons
@@ -9,46 +15,47 @@ from ckan import logic
 log = logging.getLogger()
 
 class LDAPCommand(CkanCommand):
-    """
-
-    Paster function to set up the default organisation
-
+    '''Paster function to set up the default organisation
+    
     Paster function can be included to provision scripts - otherwise, get an error after provisioning new CKAN instance
-
+    
     Commands:
-
+    
         paster ldap setup-org -c /etc/ckan/default/development.ini
 
-    """
-    summary = __doc__.split('\n')[0]
+
+    '''
+    summary = __doc__.split(u'\n')[0]
     usage = __doc__
 
 
     def command(self):
+        ''' '''
 
-        if not self.args or self.args[0] in ['--help', '-h', 'help']:
+        if not self.args or self.args[0] in [u'--help', u'-h', u'help']:
             print self.__doc__
             return
 
         self._load_config()
 
         # Set up context
-        user = toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
-        self.context = {'user': user['name']}
+        user = toolkit.get_action(u'get_site_user')({u'ignore_auth': True}, {})
+        self.context = {u'user': user[u'name']}
 
         cmd = self.args[0]
 
-        if cmd == 'setup-org':
+        if cmd == u'setup-org':
             self.setup_org()
         else:
-            print 'Command %s not recognized' % cmd
+            print u'Command %s not recognized' % cmd
 
     def setup_org(self):
+        ''' '''
 
         # Get the organisation all users will be added to
-        organization_id = pylons.config['ckanext.ldap.organization.id']
+        organization_id = pylons.config[u'ckanext.ldap.organization.id']
 
         try:
-            toolkit.get_action('organization_show')(self.context, {'id': organization_id})
+            toolkit.get_action(u'organization_show')(self.context, {u'id': organization_id})
         except logic.NotFound:
-            toolkit.get_action('organization_create')(self.context, {'id': organization_id, 'name': organization_id})
+            toolkit.get_action(u'organization_create')(self.context, {u'id': organization_id, u'name': organization_id})

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# This file is part of ckanext-ldap
+# Created by the Natural History Museum in London, UK
+
 import re
 import uuid
 import logging
@@ -17,28 +23,31 @@ log = logging.getLogger(__name__)
 
 
 class MultipleMatchError(Exception):
+    ''' '''
     pass
 class UserConflictError(Exception):
+    ''' '''
     pass
 
 
 class UserController(p.toolkit.BaseController):
+    ''' '''
 
     def __init__(self):
-        ldap.set_option(ldap.OPT_DEBUG_LEVEL, config['ckanext.ldap.debug_level'])
+        ldap.set_option(ldap.OPT_DEBUG_LEVEL, config[u'ckanext.ldap.debug_level'])
 
     def login_handler(self):
-        """Action called when login in via the LDAP login form"""
+        '''Action called when login in via the LDAP login form'''
         params = request.POST
-        if 'login' in params and 'password' in params:
-            login = params['login']
-            password = params['password']
+        if u'login' in params and u'password' in params:
+            login = params[u'login']
+            password = params[u'password']
             try:
                 ldap_user_dict = _find_ldap_user(login)
             except MultipleMatchError as e:
                 # Multiple users match. Inform the user and try again.
                 return self._login_failed(notice=str(e))
-            if ldap_user_dict and _check_ldap_password(ldap_user_dict['cn'], password):
+            if ldap_user_dict and _check_ldap_password(ldap_user_dict[u'cn'], password):
                 try:
                     user_name = _get_or_create_ldap_user(ldap_user_dict)
                 except UserConflictError as e:
@@ -48,110 +57,115 @@ class UserController(p.toolkit.BaseController):
                 # There is an LDAP user, but the auth is wrong. There could be a CKAN user of the
                 # same name if the LDAP user had been created later - in which case we have a
                 # conflict we can't solve.
-                if config['ckanext.ldap.ckan_fallback']:
+                if config[u'ckanext.ldap.ckan_fallback']:
                     exists = _ckan_user_exists(login)
-                    if exists['exists'] and not exists['is_ldap']:
-                        return self._login_failed(error=_('Username conflict. Please contact the site administrator.'))
-                return self._login_failed(error=_('Bad username or password.'))
-            elif config['ckanext.ldap.ckan_fallback']:
+                    if exists[u'exists'] and not exists[u'is_ldap']:
+                        return self._login_failed(error=_(u'Username conflict. Please contact the site administrator.'))
+                return self._login_failed(error=_(u'Bad username or password.'))
+            elif config[u'ckanext.ldap.ckan_fallback']:
                 # No LDAP user match, see if we have a CKAN user match
                 try:
-                    user_dict = p.toolkit.get_action('user_show')(data_dict = {'id': login})
+                    user_dict = p.toolkit.get_action(u'user_show')(data_dict = {u'id': login})
                     # We need the model to validate the password
-                    user = User.by_name(user_dict['name'])
+                    user = User.by_name(user_dict[u'name'])
                 except p.toolkit.ObjectNotFound:
                     user = None
                 if user and user.validate_password(password):
                     return self._login_success(user.name)
                 else:
-                    return self._login_failed(error=_('Bad username or password.'))
+                    return self._login_failed(error=_(u'Bad username or password.'))
             else:
-                return self._login_failed(error=_('Bad username or password.'))
-        return self._login_failed(error=_('Please enter a username and password'))
+                return self._login_failed(error=_(u'Bad username or password.'))
+        return self._login_failed(error=_(u'Please enter a username and password'))
 
     def _login_failed(self, notice=None, error=None):
-        """Handle login failures
-
+        '''Handle login failures
+        
         Redirect to /user/login and flash an optional message
 
-        @param notice: Optional notice for the user
-        @param error: Optional error message for the user
-        """
+        :param notice: Optional notice for the user (Default value = None)
+        :param error: Optional error message for the user (Default value = None)
+
+        '''
         if notice:
             flash_notice(notice)
         if error:
             flash_error(error)
-        p.toolkit.redirect_to(controller='user', action='login')
+        p.toolkit.redirect_to(controller=u'user', action=u'login')
 
     def _login_success(self, user_name):
-        """Handle login success
-
+        '''Handle login success
+        
         Saves the user in the session and redirects to user/logged_in
 
-        @param user_name: The user name
-        """
-        pylons.session['ckanext-ldap-user'] = user_name
+        :param user_name: The user name
+
+        '''
+        pylons.session[u'ckanext-ldap-user'] = user_name
         pylons.session.save()
-        p.toolkit.redirect_to(controller='user', action='dashboard', id=user_name)
+        p.toolkit.redirect_to(controller=u'user', action=u'dashboard', id=user_name)
 
 
 def _ckan_user_exists(user_name):
-    """Check if a CKAN user name exists, and if that user is an LDAP user.
+    '''Check if a CKAN user name exists, and if that user is an LDAP user.
 
-    @param user_name: User name to check
-    @return: Dictionary defining 'exists' and 'ldap'.
-    """
+    :param user_name: User name to check
+    :returns: Dictionary defining 'exists' and 'ldap'.
+
+    '''
     try:
-        user = p.toolkit.get_action('user_show')(data_dict = {'id': user_name})
+        user = p.toolkit.get_action(u'user_show')(data_dict = {u'id': user_name})
     except p.toolkit.ObjectNotFound:
-        return {'exists': False, 'is_ldap': False}
+        return {u'exists': False, u'is_ldap': False}
 
-    ldap_user = LdapUser.by_user_id(user['id'])
+    ldap_user = LdapUser.by_user_id(user[u'id'])
     if ldap_user:
-        return {'exists': True, 'is_ldap': True}
+        return {u'exists': True, u'is_ldap': True}
     else:
-        return {'exists': True, 'is_ldap': False}
+        return {u'exists': True, u'is_ldap': False}
 
 
 def _get_unique_user_name(base_name):
-    """Create a unique, valid, non existent user name from the given base name
+    '''Create a unique, valid, non existent user name from the given base name
 
-    @param base_name: Base name
-    @return: A valid user name not currently in use based on base_name
-    """
-    base_name = re.sub('[^-a-z0-9_]', '_', base_name.lower())
+    :param base_name: Base name
+    :returns: A valid user name not currently in use based on base_name
+
+    '''
+    base_name = re.sub(u'[^-a-z0-9_]', u'_', base_name.lower())
     base_name = base_name[0:100]
     if len(base_name) < 2:
-        base_name = (base_name + "__")[0:2]
+        base_name = (base_name + u'__')[0:2]
     count = 0
     user_name = base_name
-    while (_ckan_user_exists(user_name))['exists']:
+    while (_ckan_user_exists(user_name))[u'exists']:
         count += 1
-        user_name = "{base}{count}".format(base=base_name[0:100-len(str(count))], count=str(count))
+        user_name = u'{base}{count}'.format(base=base_name[0:100-len(str(count))], count=str(count))
     return user_name
 
 
 def _get_or_create_ldap_user(ldap_user_dict):
-    """Get or create a CKAN user from the data returned by the LDAP server
+    '''Get or create a CKAN user from the data returned by the LDAP server
 
-    @param ldap_user_dict: Dictionary as returned by _find_ldap_user
-    @return: The CKAN username of an existing user
-    """
+    :param ldap_user_dict: Dictionary as returned by _find_ldap_user
+    :returns: The CKAN username of an existing user
+
+    '''
     # Look for existing user, and if found return it.
-    ldap_user = LdapUser.by_ldap_id(ldap_user_dict['username'])
+    ldap_user = LdapUser.by_ldap_id(ldap_user_dict[u'username'])
     if ldap_user:
         # TODO: Update the user detail.
         return ldap_user.user.name
     user_dict = {}
     update=False
     # Check whether we have a name conflict (based on the ldap name, without mapping it to allowed chars)
-    exists = _ckan_user_exists(ldap_user_dict['username'])
-    if exists['exists'] and not exists['is_ldap']:
+    exists = _ckan_user_exists(ldap_user_dict[u'username'])
+    if exists[u'exists'] and not exists[u'is_ldap']:
         # If ckanext.ldap.migrate is set, update exsting user_dict.
-        if not config['ckanext.ldap.migrate']:
-             raise UserConflictError(_('There is a username conflict. Please inform the site administrator.'))
+        if not config[u'ckanext.ldap.migrate']:
+             raise UserConflictError(_(u'There is a username conflict. Please inform the site administrator.'))
         else:
-            user_dict = p.toolkit.get_action('user_show')(data_dict = {'id': ldap_user_dict['username']})
+            user_dict = p.toolkit.get_action(u'user_show')(data_dict = {u'id': ldap_user_dict[u'username']})
             update=True
         
     # If a user with the same ckan name already exists but is an LDAP user, this means (given that we didn't
@@ -160,141 +174,143 @@ def _get_or_create_ldap_user(ldap_user_dict):
     # user's id will just be mangled to something different.
 
     # Now get a unique user name (if not "migrating"), and create the CKAN user and the LdapUser entry.
-    user_name = user_dict['name'] if update else _get_unique_user_name(ldap_user_dict['username'])
+    user_name = user_dict[u'name'] if update else _get_unique_user_name(ldap_user_dict[u'username'])
     user_dict.update({
-        'name': user_name,
-        'email': ldap_user_dict['email'],
-        'password': str(uuid.uuid4())
+        u'name': user_name,
+        u'email': ldap_user_dict[u'email'],
+        u'password': str(uuid.uuid4())
     })
-    if 'fullname' in ldap_user_dict:
-        user_dict['fullname'] = ldap_user_dict['fullname']
-    if 'about' in ldap_user_dict:
-        user_dict['about'] = ldap_user_dict['about']
+    if u'fullname' in ldap_user_dict:
+        user_dict[u'fullname'] = ldap_user_dict[u'fullname']
+    if u'about' in ldap_user_dict:
+        user_dict[u'about'] = ldap_user_dict[u'about']
     if update:
-        ckan_user = p.toolkit.get_action('user_update')(
-            context={'ignore_auth': True},
+        ckan_user = p.toolkit.get_action(u'user_update')(
+            context={u'ignore_auth': True},
             data_dict=user_dict
         )
     else:
-        ckan_user = p.toolkit.get_action('user_create')(
-            context={'ignore_auth': True},
+        ckan_user = p.toolkit.get_action(u'user_create')(
+            context={u'ignore_auth': True},
             data_dict=user_dict
         )
-    ldap_user = LdapUser(user_id=ckan_user['id'], ldap_id = ldap_user_dict['username'])
+    ldap_user = LdapUser(user_id=ckan_user[u'id'], ldap_id = ldap_user_dict[u'username'])
     ckan.model.Session.add(ldap_user)
     ckan.model.Session.commit()
     # Add the user to it's group if needed
-    if 'ckanext.ldap.organization.id' in config:
-        p.toolkit.get_action('member_create')(
-            context={'ignore_auth': True},
+    if u'ckanext.ldap.organization.id' in config:
+        p.toolkit.get_action(u'member_create')(
+            context={u'ignore_auth': True},
             data_dict={
-                'id': config['ckanext.ldap.organization.id'],
-                'object': user_name,
-                'object_type': 'user',
-                'capacity': config['ckanext.ldap.organization.role']
+                u'id': config[u'ckanext.ldap.organization.id'],
+                u'object': user_name,
+                u'object_type': u'user',
+                u'capacity': config[u'ckanext.ldap.organization.role']
             }
         )
     return user_name
 
 
 def _find_ldap_user(login):
-    """Find the LDAP user identified by 'login' in the configured ldap database
+    '''Find the LDAP user identified by 'login' in the configured ldap database
 
-    @param login: The login to find in the LDAP database
-    @return: None if no user is found, a dictionary defining 'cn', 'username', 'fullname' and 'email otherwise.
-    """
-    cnx = ldap.initialize(config['ckanext.ldap.uri'], bytes_mode=False,
-                          trace_level=config['ckanext.ldap.trace_level'])
-    if config.get('ckanext.ldap.auth.dn'):
+    :param login: The login to find in the LDAP database
+    :returns: None if no user is found, a dictionary defining 'cn', 'username', 'fullname' and 'email otherwise.
+
+    '''
+    cnx = ldap.initialize(config[u'ckanext.ldap.uri'], bytes_mode=False,
+                          trace_level=config[u'ckanext.ldap.trace_level'])
+    if config.get(u'ckanext.ldap.auth.dn'):
         try:
-            if config['ckanext.ldap.auth.method'] == 'SIMPLE':
-                cnx.bind_s(config['ckanext.ldap.auth.dn'], config['ckanext.ldap.auth.password'])
-            elif config['ckanext.ldap.auth.method'] == 'SASL':
-                if config['ckanext.ldap.auth.mechanism'] == 'DIGEST-MD5':
-                    auth_tokens = ldap.sasl.digest_md5(config['ckanext.ldap.auth.dn'], config['ckanext.ldap.auth.password'])
-                    cnx.sasl_interactive_bind_s("", auth_tokens)
+            if config[u'ckanext.ldap.auth.method'] == u'SIMPLE':
+                cnx.bind_s(config[u'ckanext.ldap.auth.dn'], config[u'ckanext.ldap.auth.password'])
+            elif config[u'ckanext.ldap.auth.method'] == u'SASL':
+                if config[u'ckanext.ldap.auth.mechanism'] == u'DIGEST-MD5':
+                    auth_tokens = ldap.sasl.digest_md5(config[u'ckanext.ldap.auth.dn'], config[u'ckanext.ldap.auth.password'])
+                    cnx.sasl_interactive_bind_s(u'', auth_tokens)
                 else:
-                    log.error("SASL mechanism not supported: {0}".format(config['ckanext.ldap.auth.mechanism']))
+                    log.error(u'SASL mechanism not supported: {0}'.format(config[u'ckanext.ldap.auth.mechanism']))
                     return None
             else:
-                log.error("LDAP authentication method is not supported: {0}".format(config['ckanext.ldap.auth.method']))
+                log.error(u'LDAP authentication method is not supported: {0}'.format(config[u'ckanext.ldap.auth.method']))
                 return None
         except ldap.SERVER_DOWN:
-            log.error('LDAP server is not reachable')
+            log.error(u'LDAP server is not reachable')
             return None
         except ldap.INVALID_CREDENTIALS:
-            log.error('LDAP server credentials (ckanext.ldap.auth.dn and ckanext.ldap.auth.password) invalid')
+            log.error(u'LDAP server credentials (ckanext.ldap.auth.dn and ckanext.ldap.auth.password) invalid')
             return None
         except ldap.LDAPError, e:
-            log.error("Fatal LDAP Error: {0}".format(e))
+            log.error(u'Fatal LDAP Error: {0}'.format(e))
             return None
 
-    filter_str = config['ckanext.ldap.search.filter'].format(login=ldap.filter.escape_filter_chars(login))
-    attributes = [config['ckanext.ldap.username']]
-    if 'ckanext.ldap.fullname' in config:
-        attributes.append(config['ckanext.ldap.fullname'])
-    if 'ckanext.ldap.email' in config:
-        attributes.append(config['ckanext.ldap.email'])
+    filter_str = config[u'ckanext.ldap.search.filter'].format(login=ldap.filter.escape_filter_chars(login))
+    attributes = [config[u'ckanext.ldap.username']]
+    if u'ckanext.ldap.fullname' in config:
+        attributes.append(config[u'ckanext.ldap.fullname'])
+    if u'ckanext.ldap.email' in config:
+        attributes.append(config[u'ckanext.ldap.email'])
     try:
-        ret = _ldap_search(cnx, filter_str, attributes, non_unique='log')
-        if ret is None and 'ckanext.ldap.search.alt' in config:
-            filter_str = config['ckanext.ldap.search.alt'].format(login=ldap.filter.escape_filter_chars(login))
-            ret = _ldap_search(cnx, filter_str, attributes, non_unique='raise')
+        ret = _ldap_search(cnx, filter_str, attributes, non_unique=u'log')
+        if ret is None and u'ckanext.ldap.search.alt' in config:
+            filter_str = config[u'ckanext.ldap.search.alt'].format(login=ldap.filter.escape_filter_chars(login))
+            ret = _ldap_search(cnx, filter_str, attributes, non_unique=u'raise')
     finally:
         cnx.unbind()
     return ret
 
 
-def _ldap_search(cnx, filter_str, attributes, non_unique='raise'):
-    """Helper function to perform the actual LDAP search
+def _ldap_search(cnx, filter_str, attributes, non_unique=u'raise'):
+    '''Helper function to perform the actual LDAP search
 
-    @param cnx: The LDAP connection object
-    @param filter_str: The LDAP filter string
-    @param attributes: The LDAP attributes to fetch. This *must* include self.ldap_username
-    @param non_unique: What to do when there is more than one result. Can be either 'log' (log an error
+    :param cnx: The LDAP connection object
+    :param filter_str: The LDAP filter string
+    :param attributes: The LDAP attributes to fetch. This *must* include self.ldap_username
+    :param non_unique: What to do when there is more than one result. Can be either 'log' (log an error
                        and return None - used to indicate that this is a configuration problem that needs
                        to be address by the site admin, not by the current user) or 'raise' (raise an
                        exception with a message that will be displayed to the current user - such
-                       as 'please use your unique id instead'). Other values will silently ignore the error.
-    @return: A dictionary defining 'cn', self.ldap_username and any other attributes that were defined
+                       as 'please use your unique id instead'). Other values will silently ignore the error. (Default value = u'raise')
+    :returns: A dictionary defining 'cn', self.ldap_username and any other attributes that were defined
              in attributes; or None if no user was found.
-    """
+
+    '''
     try:
-        res = cnx.search_s(config['ckanext.ldap.base_dn'], ldap.SCOPE_SUBTREE, filterstr=filter_str, attrlist=attributes)
+        res = cnx.search_s(config[u'ckanext.ldap.base_dn'], ldap.SCOPE_SUBTREE, filterstr=filter_str, attrlist=attributes)
     except ldap.SERVER_DOWN:
-        log.error('LDAP server is not reachable')
+        log.error(u'LDAP server is not reachable')
         return None
     except ldap.OPERATIONS_ERROR as e:
-        log.error('LDAP query failed. Maybe you need auth credentials for performing searches? Error returned by the server: ' + e.info)
+        log.error(u'LDAP query failed. Maybe you need auth credentials for performing searches? Error returned by the server: ' + e.info)
         return None
     except (ldap.NO_SUCH_OBJECT, ldap.REFERRAL) as e:
-        log.error('LDAP distinguished name (ckanext.ldap.base_dn) is malformed or does not exist.')
+        log.error(u'LDAP distinguished name (ckanext.ldap.base_dn) is malformed or does not exist.')
         return None
     except ldap.FILTER_ERROR:
-        log.error('LDAP filter (ckanext.ldap.search) is malformed')
+        log.error(u'LDAP filter (ckanext.ldap.search) is malformed')
         return None
     if len(res) > 1:
-        if non_unique == 'log':
-            log.error('LDAP search.filter search returned more than one entry, ignoring. Fix the search to return only 1 or 0 results.')
-        elif non_unique == 'raise':
-            raise MultipleMatchError(config['ckanext.ldap.search.alt_msg'])
+        if non_unique == u'log':
+            log.error(u'LDAP search.filter search returned more than one entry, ignoring. Fix the search to return only 1 or 0 results.')
+        elif non_unique == u'raise':
+            raise MultipleMatchError(config[u'ckanext.ldap.search.alt_msg'])
         return None
     elif len(res) == 1:
         cn = res[0][0]
         attr = res[0][1]
         ret = {
-            'cn': cn,
+            u'cn': cn,
         }
 
         # Check required fields
-        for i in ['username', 'email']:
-            cname = 'ckanext.ldap.' + i
+        for i in [u'username', u'email']:
+            cname = u'ckanext.ldap.' + i
             if config[cname] not in attr or not attr[config[cname]]:
-                log.error('LDAP search did not return a {}.'.format(i))
+                log.error(u'LDAP search did not return a {}.'.format(i))
                 return None
         # Set return dict
-        for i in ['username', 'fullname', 'email', 'about']:
-            cname = 'ckanext.ldap.' + i
+        for i in [u'username', u'fullname', u'email', u'about']:
+            cname = u'ckanext.ldap.' + i
             if cname in config and config[cname] in attr:
                 v = attr[config[cname]]
                 if v:
@@ -305,31 +321,38 @@ def _ldap_search(cnx, filter_str, attributes, non_unique='raise'):
 
 
 def _check_ldap_password(cn, password):
-    """Checks that the given cn/password credentials work on the given CN.
+    '''Checks that the given cn/password credentials work on the given CN.
 
-    @param cn: Common name to log on
-    @param password: Password for cn
-    @return: True on success, False on failure
-    """
-    cnx = ldap.initialize(config['ckanext.ldap.uri'], bytes_mode=False,
-                          trace_level=config['ckanext.ldap.trace_level'])
+    :param cn: Common name to log on
+    :param password: Password for cn
+    :returns: True on success, False on failure
+
+    '''
+    cnx = ldap.initialize(config[u'ckanext.ldap.uri'], bytes_mode=False,
+                          trace_level=config[u'ckanext.ldap.trace_level'])
     try:
         cnx.bind_s(cn, password)
     except ldap.SERVER_DOWN:
-        log.error('LDAP server is not reachable')
+        log.error(u'LDAP server is not reachable')
         return False
     except ldap.INVALID_CREDENTIALS:
-        log.debug('Invalid LDAP credentials')
+        log.debug(u'Invalid LDAP credentials')
         return False
     # Fail on empty password
-    if password == '':
-        log.debug('Invalid LDAP credentials')
+    if password == u'':
+        log.debug(u'Invalid LDAP credentials')
         return False
     cnx.unbind_s()
     return True
 
 
-def _decode_str(s, encoding='utf-8'):
+def _decode_str(s, encoding=u'utf-8'):
+    '''
+
+    :param s: 
+    :param encoding:  (Default value = u'utf-8')
+
+    '''
     try:
         # this try throws NameError if this is python3
         if isinstance(s, basestring) and isinstance(s, str):

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -345,12 +345,8 @@ def _ldap_search(cnx, filter_str, attributes, non_unique=u'raise'):
             raise MultipleMatchError(config[u'ckanext.ldap.search.alt_msg'])
         return None
     elif len(res) == 1 or (len(res) >0 and config[u'ckanext.ldap.use_first'] == True):
-        cn = ''
-        attr = ''
-
         cn = res[0][0]
         attr = res[0][1]
-
         ret = {
             u'cn': cn,
             }

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -106,7 +106,7 @@ class UserController(toolkit.BaseController):
         '''
         session[u'ckanext-ldap-user'] = user_name
         session.save()
-        toolkit.redirect_to(controller=u'user', action=u'logged_in', came_from=came_from)
+        toolkit.redirect_to(u'user.logged_in', came_from=came_from)
 
 
 def _get_user_dict(user_id):

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -4,20 +4,18 @@
 # This file is part of ckanext-ldap
 # Created by the Natural History Museum in London, UK
 
-import re
-import uuid
 import logging
-import sys
-import ldap, ldap.filter
-import ckan.plugins as p
-import ckan.model
-import pylons
+import uuid
 
-from ckan.lib.helpers import flash_notice, flash_error
-from ckan.common import _, request
-from ckan.model.user import User
-from ckanext.ldap.plugin import config
+import ldap
+import ldap.filter
+import re
 from ckanext.ldap.model.ldap_user import LdapUser
+from ckanext.ldap.plugin import config
+
+from ckan.common import session
+from ckan.model import Session, User
+from ckan.plugins import toolkit
 
 log = logging.getLogger(__name__)
 
@@ -25,12 +23,14 @@ log = logging.getLogger(__name__)
 class MultipleMatchError(Exception):
     ''' '''
     pass
+
+
 class UserConflictError(Exception):
     ''' '''
     pass
 
 
-class UserController(p.toolkit.BaseController):
+class UserController(toolkit.BaseController):
     ''' '''
 
     def __init__(self):
@@ -38,7 +38,7 @@ class UserController(p.toolkit.BaseController):
 
     def login_handler(self):
         '''Action called when login in via the LDAP login form'''
-        params = request.POST
+        params = toolkit.request.POST
         if u'login' in params and u'password' in params:
             login = params[u'login']
             password = params[u'password']
@@ -54,29 +54,34 @@ class UserController(p.toolkit.BaseController):
                     return self._login_failed(error=str(e))
                 return self._login_success(user_name)
             elif ldap_user_dict:
-                # There is an LDAP user, but the auth is wrong. There could be a CKAN user of the
-                # same name if the LDAP user had been created later - in which case we have a
-                # conflict we can't solve.
+                # There is an LDAP user, but the auth is wrong. There could be a
+                # CKAN user of the same name if the LDAP user had been created
+                # later - in which case we have a conflict we can't solve.
                 if config[u'ckanext.ldap.ckan_fallback']:
                     exists = _ckan_user_exists(login)
                     if exists[u'exists'] and not exists[u'is_ldap']:
-                        return self._login_failed(error=_(u'Username conflict. Please contact the site administrator.'))
-                return self._login_failed(error=_(u'Bad username or password.'))
+                        return self._login_failed(error=toolkit._(
+                            u'Username conflict. Please contact the site administrator.'))
+                return self._login_failed(error=toolkit._(u'Bad username or password.'))
             elif config[u'ckanext.ldap.ckan_fallback']:
                 # No LDAP user match, see if we have a CKAN user match
                 try:
-                    user_dict = p.toolkit.get_action(u'user_show')(data_dict = {u'id': login})
+                    user_dict = toolkit.get_action(u'user_show')(data_dict={
+                        u'id': login
+                        })
                     # We need the model to validate the password
                     user = User.by_name(user_dict[u'name'])
-                except p.toolkit.ObjectNotFound:
+                except toolkit.ObjectNotFound:
                     user = None
                 if user and user.validate_password(password):
                     return self._login_success(user.name)
                 else:
-                    return self._login_failed(error=_(u'Bad username or password.'))
+                    return self._login_failed(
+                        error=toolkit._(u'Bad username or password.'))
             else:
-                return self._login_failed(error=_(u'Bad username or password.'))
-        return self._login_failed(error=_(u'Please enter a username and password'))
+                return self._login_failed(error=toolkit._(u'Bad username or password.'))
+        return self._login_failed(
+            error=toolkit._(u'Please enter a username and password'))
 
     def _login_failed(self, notice=None, error=None):
         '''Handle login failures
@@ -88,10 +93,10 @@ class UserController(p.toolkit.BaseController):
 
         '''
         if notice:
-            flash_notice(notice)
+            toolkit.h.flash_notice(notice)
         if error:
-            flash_error(error)
-        p.toolkit.redirect_to(controller=u'user', action=u'login')
+            toolkit.h.flash_error(error)
+        toolkit.redirect_to(controller=u'user', action=u'login')
 
     def _login_success(self, user_name):
         '''Handle login success
@@ -101,9 +106,9 @@ class UserController(p.toolkit.BaseController):
         :param user_name: The user name
 
         '''
-        pylons.session[u'ckanext-ldap-user'] = user_name
-        pylons.session.save()
-        p.toolkit.redirect_to(controller=u'user', action=u'dashboard', id=user_name)
+        session[u'ckanext-ldap-user'] = user_name
+        session.save()
+        toolkit.redirect_to(controller=u'user', action=u'dashboard', id=user_name)
 
 
 def _ckan_user_exists(user_name):
@@ -114,15 +119,26 @@ def _ckan_user_exists(user_name):
 
     '''
     try:
-        user = p.toolkit.get_action(u'user_show')(data_dict = {u'id': user_name})
-    except p.toolkit.ObjectNotFound:
-        return {u'exists': False, u'is_ldap': False}
+        user = toolkit.get_action(u'user_show')(data_dict={
+            u'id': user_name
+            })
+    except toolkit.ObjectNotFound:
+        return {
+            u'exists': False,
+            u'is_ldap': False
+            }
 
     ldap_user = LdapUser.by_user_id(user[u'id'])
     if ldap_user:
-        return {u'exists': True, u'is_ldap': True}
+        return {
+            u'exists': True,
+            u'is_ldap': True
+            }
     else:
-        return {u'exists': True, u'is_ldap': False}
+        return {
+            u'exists': True,
+            u'is_ldap': False
+            }
 
 
 def _get_unique_user_name(base_name):
@@ -140,7 +156,8 @@ def _get_unique_user_name(base_name):
     user_name = base_name
     while (_ckan_user_exists(user_name))[u'exists']:
         count += 1
-        user_name = u'{base}{count}'.format(base=base_name[0:100-len(str(count))], count=str(count))
+        user_name = u'{base}{count}'.format(base=base_name[0:100 - len(str(count))],
+                                            count=str(count))
     return user_name
 
 
@@ -157,57 +174,70 @@ def _get_or_create_ldap_user(ldap_user_dict):
         # TODO: Update the user detail.
         return ldap_user.user.name
     user_dict = {}
-    update=False
-    # Check whether we have a name conflict (based on the ldap name, without mapping it to allowed chars)
+    update = False
+    # Check whether we have a name conflict (based on the ldap name, without mapping
+    # it to allowed chars)
     exists = _ckan_user_exists(ldap_user_dict[u'username'])
     if exists[u'exists'] and not exists[u'is_ldap']:
         # If ckanext.ldap.migrate is set, update exsting user_dict.
         if not config[u'ckanext.ldap.migrate']:
-             raise UserConflictError(_(u'There is a username conflict. Please inform the site administrator.'))
+            raise UserConflictError(toolkit._(
+                u'There is a username conflict. Please inform the site administrator.'))
         else:
-            user_dict = p.toolkit.get_action(u'user_show')(data_dict = {u'id': ldap_user_dict[u'username']})
-            update=True
-        
-    # If a user with the same ckan name already exists but is an LDAP user, this means (given that we didn't
-    # find it above) that the conflict arises from having mangled another user's LDAP name. There will not
-    # however be a conflict based on what is entered in the user prompt - so we can go ahead. The current
-    # user's id will just be mangled to something different.
+            user_dict = toolkit.get_action(u'user_show')(data_dict={
+                u'id': ldap_user_dict[u'username']
+                })
+            update = True
 
-    # Now get a unique user name (if not "migrating"), and create the CKAN user and the LdapUser entry.
-    user_name = user_dict[u'name'] if update else _get_unique_user_name(ldap_user_dict[u'username'])
+    # If a user with the same ckan name already exists but is an LDAP user, this means
+    # (given that we didn't find it above) that the conflict arises from having mangled
+    # another user's LDAP name. There will not however be a conflict based on what is
+    # entered in the user prompt - so we can go ahead. The current user's id will just
+    # be mangled to something different.
+
+    # Now get a unique user name (if not "migrating"), and create the CKAN user and
+    # the LdapUser entry.
+    user_name = user_dict[u'name'] if update else _get_unique_user_name(
+        ldap_user_dict[u'username'])
     user_dict.update({
         u'name': user_name,
         u'email': ldap_user_dict[u'email'],
         u'password': str(uuid.uuid4())
-    })
+        })
     if u'fullname' in ldap_user_dict:
         user_dict[u'fullname'] = ldap_user_dict[u'fullname']
     if u'about' in ldap_user_dict:
         user_dict[u'about'] = ldap_user_dict[u'about']
     if update:
-        ckan_user = p.toolkit.get_action(u'user_update')(
-            context={u'ignore_auth': True},
+        ckan_user = toolkit.get_action(u'user_update')(
+            context={
+                u'ignore_auth': True
+                },
             data_dict=user_dict
-        )
+            )
     else:
-        ckan_user = p.toolkit.get_action(u'user_create')(
-            context={u'ignore_auth': True},
+        ckan_user = toolkit.get_action(u'user_create')(
+            context={
+                u'ignore_auth': True
+                },
             data_dict=user_dict
-        )
-    ldap_user = LdapUser(user_id=ckan_user[u'id'], ldap_id = ldap_user_dict[u'username'])
-    ckan.model.Session.add(ldap_user)
-    ckan.model.Session.commit()
+            )
+    ldap_user = LdapUser(user_id=ckan_user[u'id'], ldap_id=ldap_user_dict[u'username'])
+    Session.add(ldap_user)
+    Session.commit()
     # Add the user to it's group if needed
     if u'ckanext.ldap.organization.id' in config:
-        p.toolkit.get_action(u'member_create')(
-            context={u'ignore_auth': True},
+        toolkit.get_action(u'member_create')(
+            context={
+                u'ignore_auth': True
+                },
             data_dict={
                 u'id': config[u'ckanext.ldap.organization.id'],
                 u'object': user_name,
                 u'object_type': u'user',
                 u'capacity': config[u'ckanext.ldap.organization.role']
-            }
-        )
+                }
+            )
     return user_name
 
 
@@ -215,7 +245,8 @@ def _find_ldap_user(login):
     '''Find the LDAP user identified by 'login' in the configured ldap database
 
     :param login: The login to find in the LDAP database
-    :returns: None if no user is found, a dictionary defining 'cn', 'username', 'fullname' and 'email otherwise.
+    :returns: None if no user is found, a dictionary defining 'cn', 'username',
+              'fullname' and 'email otherwise.
 
     '''
     cnx = ldap.initialize(config[u'ckanext.ldap.uri'], bytes_mode=False,
@@ -223,28 +254,35 @@ def _find_ldap_user(login):
     if config.get(u'ckanext.ldap.auth.dn'):
         try:
             if config[u'ckanext.ldap.auth.method'] == u'SIMPLE':
-                cnx.bind_s(config[u'ckanext.ldap.auth.dn'], config[u'ckanext.ldap.auth.password'])
+                cnx.bind_s(config[u'ckanext.ldap.auth.dn'],
+                           config[u'ckanext.ldap.auth.password'])
             elif config[u'ckanext.ldap.auth.method'] == u'SASL':
                 if config[u'ckanext.ldap.auth.mechanism'] == u'DIGEST-MD5':
-                    auth_tokens = ldap.sasl.digest_md5(config[u'ckanext.ldap.auth.dn'], config[u'ckanext.ldap.auth.password'])
+                    auth_tokens = ldap.sasl.digest_md5(config[u'ckanext.ldap.auth.dn'],
+                                                       config[
+                                                           u'ckanext.ldap.auth.password'])
                     cnx.sasl_interactive_bind_s(u'', auth_tokens)
                 else:
-                    log.error(u'SASL mechanism not supported: {0}'.format(config[u'ckanext.ldap.auth.mechanism']))
+                    log.error(u'SASL mechanism not supported: {0}'.format(
+                        config[u'ckanext.ldap.auth.mechanism']))
                     return None
             else:
-                log.error(u'LDAP authentication method is not supported: {0}'.format(config[u'ckanext.ldap.auth.method']))
+                log.error(u'LDAP authentication method is not supported: {0}'.format(
+                    config[u'ckanext.ldap.auth.method']))
                 return None
         except ldap.SERVER_DOWN:
             log.error(u'LDAP server is not reachable')
             return None
         except ldap.INVALID_CREDENTIALS:
-            log.error(u'LDAP server credentials (ckanext.ldap.auth.dn and ckanext.ldap.auth.password) invalid')
+            log.error(
+                u'LDAP server credentials (ckanext.ldap.auth.dn and ckanext.ldap.auth.password) invalid')
             return None
         except ldap.LDAPError, e:
             log.error(u'Fatal LDAP Error: {0}'.format(e))
             return None
 
-    filter_str = config[u'ckanext.ldap.search.filter'].format(login=ldap.filter.escape_filter_chars(login))
+    filter_str = config[u'ckanext.ldap.search.filter'].format(
+        login=ldap.filter.escape_filter_chars(login))
     attributes = [config[u'ckanext.ldap.username']]
     if u'ckanext.ldap.fullname' in config:
         attributes.append(config[u'ckanext.ldap.fullname'])
@@ -253,7 +291,8 @@ def _find_ldap_user(login):
     try:
         ret = _ldap_search(cnx, filter_str, attributes, non_unique=u'log')
         if ret is None and u'ckanext.ldap.search.alt' in config:
-            filter_str = config[u'ckanext.ldap.search.alt'].format(login=ldap.filter.escape_filter_chars(login))
+            filter_str = config[u'ckanext.ldap.search.alt'].format(
+                login=ldap.filter.escape_filter_chars(login))
             ret = _ldap_search(cnx, filter_str, attributes, non_unique=u'raise')
     finally:
         cnx.unbind()
@@ -266,32 +305,38 @@ def _ldap_search(cnx, filter_str, attributes, non_unique=u'raise'):
     :param cnx: The LDAP connection object
     :param filter_str: The LDAP filter string
     :param attributes: The LDAP attributes to fetch. This *must* include self.ldap_username
-    :param non_unique: What to do when there is more than one result. Can be either 'log' (log an error
-                       and return None - used to indicate that this is a configuration problem that needs
-                       to be address by the site admin, not by the current user) or 'raise' (raise an
-                       exception with a message that will be displayed to the current user - such
-                       as 'please use your unique id instead'). Other values will silently ignore the error. (Default value = u'raise')
-    :returns: A dictionary defining 'cn', self.ldap_username and any other attributes that were defined
-             in attributes; or None if no user was found.
+    :param non_unique: What to do when there is more than one result. Can be either
+                       'log' (log an error and return None - used to indicate that this
+                       is a configuration problem that needs to be address by the site
+                       admin, not by the current user) or 'raise' (raise an exception
+                       with a message that will be displayed to the current user - such
+                       as 'please use your unique id instead'). Other values will
+                       silently ignore the error. (Default value = u'raise')
+    :returns: A dictionary defining 'cn', self.ldap_username and any other attributes
+              that were defined in attributes; or None if no user was found.
 
     '''
     try:
-        res = cnx.search_s(config[u'ckanext.ldap.base_dn'], ldap.SCOPE_SUBTREE, filterstr=filter_str, attrlist=attributes)
+        res = cnx.search_s(config[u'ckanext.ldap.base_dn'], ldap.SCOPE_SUBTREE,
+                           filterstr=filter_str, attrlist=attributes)
     except ldap.SERVER_DOWN:
         log.error(u'LDAP server is not reachable')
         return None
     except ldap.OPERATIONS_ERROR as e:
-        log.error(u'LDAP query failed. Maybe you need auth credentials for performing searches? Error returned by the server: ' + e.info)
+        log.error(
+            u'LDAP query failed. Maybe you need auth credentials for performing searches? Error returned by the server: ' + e.info)
         return None
     except (ldap.NO_SUCH_OBJECT, ldap.REFERRAL) as e:
-        log.error(u'LDAP distinguished name (ckanext.ldap.base_dn) is malformed or does not exist.')
+        log.error(
+            u'LDAP distinguished name (ckanext.ldap.base_dn) is malformed or does not exist.')
         return None
     except ldap.FILTER_ERROR:
         log.error(u'LDAP filter (ckanext.ldap.search) is malformed')
         return None
     if len(res) > 1:
         if non_unique == u'log':
-            log.error(u'LDAP search.filter search returned more than one entry, ignoring. Fix the search to return only 1 or 0 results.')
+            log.error(
+                u'LDAP search.filter search returned more than one entry, ignoring. Fix the search to return only 1 or 0 results.')
         elif non_unique == u'raise':
             raise MultipleMatchError(config[u'ckanext.ldap.search.alt_msg'])
         return None
@@ -300,7 +345,7 @@ def _ldap_search(cnx, filter_str, attributes, non_unique=u'raise'):
         attr = res[0][1]
         ret = {
             u'cn': cn,
-        }
+            }
 
         # Check required fields
         for i in [u'username', u'email']:
@@ -358,6 +403,6 @@ def _decode_str(s, encoding=u'utf-8'):
         if isinstance(s, basestring) and isinstance(s, str):
             return unicode(s, encoding)
     except NameError:
-        if isinstance (s, bytes):
+        if isinstance(s, bytes):
             return s.decode(encoding)
     return s

--- a/ckanext/ldap/controllers/user.py
+++ b/ckanext/ldap/controllers/user.py
@@ -337,16 +337,20 @@ def _ldap_search(cnx, filter_str, attributes, non_unique=u'raise'):
     except ldap.FILTER_ERROR:
         log.error(u'LDAP filter (ckanext.ldap.search) is malformed')
         return None
-    if len(res) > 1:
+    if len(res) > 1 and config[u'ckanext.ldap.use_first'] == False:
         if non_unique == u'log':
             log.error(
                 u'LDAP search.filter search returned more than one entry, ignoring. Fix the search to return only 1 or 0 results.')
         elif non_unique == u'raise':
             raise MultipleMatchError(config[u'ckanext.ldap.search.alt_msg'])
         return None
-    elif len(res) == 1:
+    elif len(res) == 1 or (len(res) >0 and config[u'ckanext.ldap.use_first'] == True):
+        cn = ''
+        attr = ''
+
         cn = res[0][0]
         attr = res[0][1]
+
         ret = {
             u'cn': cn,
             }

--- a/ckanext/ldap/lib/__init__.py
+++ b/ckanext/ldap/lib/__init__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # encoding: utf-8
-"""
-Created by 'bens3' on 2013-06-21.
-Copyright (c) 2013 'bens3'. All rights reserved.
-"""
+#
+# This file is part of ckanext-ldap
+# Created by the Natural History Museum in London, UK

--- a/ckanext/ldap/lib/helpers.py
+++ b/ckanext/ldap/lib/helpers.py
@@ -1,17 +1,19 @@
+
 #!/usr/bin/env python
 # encoding: utf-8
-"""
-Created by 'bens3' on 2013-06-21.
-Copyright (c) 2013 'bens3'. All rights reserved.
-"""
+#
+# This file is part of ckanext-ldap
+# Created by the Natural History Museum in London, UK
 
 import pylons
 
 
 def is_ldap_user():
-    """
-    Help function for determining if current user is LDAP user
-    @return: boolean
-    """
+    '''Help function for determining if current user is LDAP user
 
-    return 'ckanext-ldap-user' in pylons.session
+
+    :returns: boolean
+
+    '''
+
+    return u'ckanext-ldap-user' in pylons.session

--- a/ckanext/ldap/lib/helpers.py
+++ b/ckanext/ldap/lib/helpers.py
@@ -1,19 +1,18 @@
-
-#!/usr/bin/env python
+# !/usr/bin/env python
 # encoding: utf-8
 #
 # This file is part of ckanext-ldap
 # Created by the Natural History Museum in London, UK
 
-import pylons
+from ckan.common import session
 
 
 def is_ldap_user():
-    '''Help function for determining if current user is LDAP user
+    '''Helper function for determining if current user is LDAP user
 
 
     :returns: boolean
 
     '''
 
-    return u'ckanext-ldap-user' in pylons.session
+    return u'ckanext-ldap-user' in session

--- a/ckanext/ldap/logic/auth/create.py
+++ b/ckanext/ldap/logic/auth/create.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# This file is part of ckanext-ldap
+# Created by the Natural History Museum in London, UK
+
 import ckan.logic, ckan.logic.auth
 from ckan.common import _
 from ckan.logic.auth.create import user_create as ckan_user_create
@@ -6,9 +12,15 @@ from ckanext.ldap.controllers.user import _find_ldap_user
 
 @ckan.logic.auth_allow_anonymous_access
 def user_create(context, data_dict=None):
-    if data_dict and 'name' in data_dict:
-        ldap_user_dict = _find_ldap_user(data_dict['name'])
+    '''
+
+    :param context: 
+    :param data_dict:  (Default value = None)
+
+    '''
+    if data_dict and u'name' in data_dict:
+        ldap_user_dict = _find_ldap_user(data_dict[u'name'])
         if ldap_user_dict:
-            return {'success': False, 'msg': _('An LDAP user by that name already exists')}
+            return {u'success': False, u'msg': _(u'An LDAP user by that name already exists')}
 
     return ckan_user_create(context, data_dict)

--- a/ckanext/ldap/logic/auth/create.py
+++ b/ckanext/ldap/logic/auth/create.py
@@ -4,23 +4,27 @@
 # This file is part of ckanext-ldap
 # Created by the Natural History Museum in London, UK
 
-import ckan.logic, ckan.logic.auth
-from ckan.common import _
-from ckan.logic.auth.create import user_create as ckan_user_create
 from ckanext.ldap.controllers.user import _find_ldap_user
 
+from ckan.plugins import toolkit
 
-@ckan.logic.auth_allow_anonymous_access
-def user_create(context, data_dict=None):
+
+@toolkit.chained_auth_function
+@toolkit.auth_allow_anonymous_access
+def user_create(next_auth, context, data_dict=None):
     '''
 
-    :param context: 
+    :param next_auth: the next auth function in the chain
+    :param context:
     :param data_dict:  (Default value = None)
 
     '''
     if data_dict and u'name' in data_dict:
         ldap_user_dict = _find_ldap_user(data_dict[u'name'])
         if ldap_user_dict:
-            return {u'success': False, u'msg': _(u'An LDAP user by that name already exists')}
+            return {
+                u'success': False,
+                u'msg': toolkit._(u'An LDAP user by that name already exists')
+                }
 
-    return ckan_user_create(context, data_dict)
+    return next_auth(context, data_dict)

--- a/ckanext/ldap/logic/auth/update.py
+++ b/ckanext/ldap/logic/auth/update.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# This file is part of ckanext-ldap
+# Created by the Natural History Museum in London, UK
+
 import ckan.logic, ckan.logic.auth
 from ckan.common import _
 from ckan.logic.auth.update import user_update as ckan_user_update
@@ -7,20 +13,25 @@ from ckanext.ldap.controllers.user import _find_ldap_user
 
 @ckan.logic.auth_allow_anonymous_access
 def user_update(context, data_dict):
-    """Ensure LDAP users cannot be edited, and name clash with ldap users"""
+    '''Ensure LDAP users cannot be edited, and name clash with ldap users
+
+    :param context: 
+    :param data_dict: 
+
+    '''
     user_obj = None
     try:
         user_obj = ckan.logic.auth.get_user_object(context, data_dict)
     except ckan.logic.NotFound:
         pass
     # Prevent edition of LDAP users (if so configured)
-    if config['ckanext.ldap.prevent_edits'] and user_obj and LdapUser.by_user_id(user_obj.id):
-        return {'success': False, 'msg': _('Cannot edit LDAP users')}
+    if config[u'ckanext.ldap.prevent_edits'] and user_obj and LdapUser.by_user_id(user_obj.id):
+        return {u'success': False, u'msg': _(u'Cannot edit LDAP users')}
     # Prevent name clashes!
-    if 'name' in data_dict and user_obj and user_obj.name != data_dict['name']:
-        ldap_user_dict = _find_ldap_user(data_dict['name'])
+    if u'name' in data_dict and user_obj and user_obj.name != data_dict[u'name']:
+        ldap_user_dict = _find_ldap_user(data_dict[u'name'])
         if ldap_user_dict:
-            if len(user_obj.ldap_user) == 0 or user_obj.ldap_user[0].ldap_id != ldap_user_dict['ldap_id']:
-                return {'success': False, 'msg': _('An LDAP user by that name already exists')}
+            if len(user_obj.ldap_user) == 0 or user_obj.ldap_user[0].ldap_id != ldap_user_dict[u'ldap_id']:
+                return {u'success': False, u'msg': _(u'An LDAP user by that name already exists')}
 
     return ckan_user_update(context, data_dict)

--- a/ckanext/ldap/logic/auth/update.py
+++ b/ckanext/ldap/logic/auth/update.py
@@ -4,34 +4,45 @@
 # This file is part of ckanext-ldap
 # Created by the Natural History Museum in London, UK
 
-import ckan.logic, ckan.logic.auth
-from ckan.common import _
-from ckan.logic.auth.update import user_update as ckan_user_update
-from ckanext.ldap.plugin import config
-from ckanext.ldap.model.ldap_user import LdapUser
 from ckanext.ldap.controllers.user import _find_ldap_user
+from ckanext.ldap.model.ldap_user import LdapUser
+from ckanext.ldap.plugin import config
 
-@ckan.logic.auth_allow_anonymous_access
-def user_update(context, data_dict):
+from ckan.logic import auth
+from ckan.plugins import toolkit
+
+
+@toolkit.chained_auth_function
+@toolkit.auth_allow_anonymous_access
+def user_update(next_auth, context, data_dict):
     '''Ensure LDAP users cannot be edited, and name clash with ldap users
 
+    :param next_auth: the next auth function in the chain
     :param context: 
     :param data_dict: 
 
     '''
     user_obj = None
     try:
-        user_obj = ckan.logic.auth.get_user_object(context, data_dict)
-    except ckan.logic.NotFound:
+        user_obj = auth.get_user_object(context, data_dict)
+    except toolkit.ObjectNotFound:
         pass
     # Prevent edition of LDAP users (if so configured)
-    if config[u'ckanext.ldap.prevent_edits'] and user_obj and LdapUser.by_user_id(user_obj.id):
-        return {u'success': False, u'msg': _(u'Cannot edit LDAP users')}
+    if config[u'ckanext.ldap.prevent_edits'] and user_obj and LdapUser.by_user_id(
+            user_obj.id):
+        return {
+            u'success': False,
+            u'msg': toolkit._(u'Cannot edit LDAP users')
+            }
     # Prevent name clashes!
     if u'name' in data_dict and user_obj and user_obj.name != data_dict[u'name']:
         ldap_user_dict = _find_ldap_user(data_dict[u'name'])
         if ldap_user_dict:
-            if len(user_obj.ldap_user) == 0 or user_obj.ldap_user[0].ldap_id != ldap_user_dict[u'ldap_id']:
-                return {u'success': False, u'msg': _(u'An LDAP user by that name already exists')}
+            if len(user_obj.ldap_user) == 0 or user_obj.ldap_user[0].ldap_id != \
+                    ldap_user_dict[u'ldap_id']:
+                return {
+                    u'success': False,
+                    u'msg': toolkit._(u'An LDAP user by that name already exists')
+                    }
 
-    return ckan_user_update(context, data_dict)
+    return next_auth(context, data_dict)

--- a/ckanext/ldap/model/ldap_user.py
+++ b/ckanext/ldap/model/ldap_user.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# This file is part of ckanext-ldap
+# Created by the Natural History Museum in London, UK
+
 import datetime
 
 import ckan.model.meta as meta
@@ -7,49 +13,53 @@ import ckan.model.types as _types
 
 from sqlalchemy import orm, types, Column, Table, ForeignKey
 
-__all__ = ['LdapUser']
+__all__ = [u'LdapUser']
 
-ldap_user_table = Table('ldap_user', meta.metadata,
-                     Column('id', types.UnicodeText, primary_key=True, default=_types.make_uuid),
-                     Column('user_id', types.UnicodeText, ForeignKey('user.id'), unique=True, nullable=False),
-                     Column('ldap_id', types.UnicodeText, index=True, unique=True, nullable=False),
-                     Column('created', types.DateTime, default=datetime.datetime.now)
+ldap_user_table = Table(u'ldap_user', meta.metadata,
+                     Column(u'id', types.UnicodeText, primary_key=True, default=_types.make_uuid),
+                     Column(u'user_id', types.UnicodeText, ForeignKey(u'user.id'), unique=True, nullable=False),
+                     Column(u'ldap_id', types.UnicodeText, index=True, unique=True, nullable=False),
+                     Column(u'created', types.DateTime, default=datetime.datetime.now)
                      )
 
 def setup():
-    """Model setup; ensure our table exists"""
+    '''Model setup; ensure our table exists'''
     if not ldap_user_table.exists() and user.user_table.exists():
         ldap_user_table.create()
 
 class LdapUser(domain_object.DomainObject):
-    """Represents an entry mapping a ldap id to a CKAN user"""
+    '''Represents an entry mapping a ldap id to a CKAN user'''
     @classmethod
     def by_ldap_id(cls, ldap_id, autoflush=True):
-        """Return the LdapUser object mapping the given ldap id
+        '''Return the LdapUser object mapping the given ldap id
 
-        @param ldap_id: ldap id, as returned by the LDAP server
-        @return: LdapUser object or None
-        """
+        :param ldap_id: ldap id, as returned by the LDAP server
+        :param autoflush:  (Default value = True)
+        :returns: LdapUser object or None
+
+        '''
         obj = meta.Session.query(cls).autoflush(autoflush)\
               .filter_by(ldap_id=ldap_id).first()
         return obj
 
     @classmethod
     def by_user_id(cls, user_id, autoflush=True):
-        """Return the LdapUser object mapping the given user id
+        '''Return the LdapUser object mapping the given user id
 
-        @param user_id: CKAN user id (actual id, not name)
-        @return: LdapUser object or None
-        """
+        :param user_id: CKAN user id (actual id, not name)
+        :param autoflush:  (Default value = True)
+        :returns: LdapUser object or None
+
+        '''
         obj = meta.Session.query(cls).autoflush(autoflush)\
               .filter_by(user_id=user_id).first()
         return obj
 
 meta.mapper(LdapUser, ldap_user_table,
        properties={
-            'user': orm.relation(user.User,
-                backref=orm.backref('ldap_user',
-                cascade='all, delete, delete-orphan'
+            u'user': orm.relation(user.User,
+                backref=orm.backref(u'ldap_user',
+                cascade=u'all, delete, delete-orphan'
                 ))
             },
        )

--- a/ckanext/ldap/model/ldap_user.py
+++ b/ckanext/ldap/model/ldap_user.py
@@ -6,29 +6,32 @@
 
 import datetime
 
-import ckan.model.meta as meta
-import ckan.model.user as user
-import ckan.model.domain_object as domain_object
-import ckan.model.types as _types
+from sqlalchemy import Column, ForeignKey, Table, orm, types
 
-from sqlalchemy import orm, types, Column, Table, ForeignKey
+from ckan import model
 
 __all__ = [u'LdapUser']
 
-ldap_user_table = Table(u'ldap_user', meta.metadata,
-                     Column(u'id', types.UnicodeText, primary_key=True, default=_types.make_uuid),
-                     Column(u'user_id', types.UnicodeText, ForeignKey(u'user.id'), unique=True, nullable=False),
-                     Column(u'ldap_id', types.UnicodeText, index=True, unique=True, nullable=False),
-                     Column(u'created', types.DateTime, default=datetime.datetime.now)
-                     )
+ldap_user_table = Table(u'ldap_user', model.meta.metadata,
+                        Column(u'id', types.UnicodeText, primary_key=True,
+                               default=model.types.make_uuid),
+                        Column(u'user_id', types.UnicodeText, ForeignKey(u'user.id'),
+                               unique=True, nullable=False),
+                        Column(u'ldap_id', types.UnicodeText, index=True, unique=True,
+                               nullable=False),
+                        Column(u'created', types.DateTime, default=datetime.datetime.now)
+                        )
+
 
 def setup():
     '''Model setup; ensure our table exists'''
-    if not ldap_user_table.exists() and user.user_table.exists():
+    if not ldap_user_table.exists() and model.user.user_table.exists():
         ldap_user_table.create()
 
-class LdapUser(domain_object.DomainObject):
+
+class LdapUser(model.domain_object.DomainObject):
     '''Represents an entry mapping a ldap id to a CKAN user'''
+
     @classmethod
     def by_ldap_id(cls, ldap_id, autoflush=True):
         '''Return the LdapUser object mapping the given ldap id
@@ -38,8 +41,8 @@ class LdapUser(domain_object.DomainObject):
         :returns: LdapUser object or None
 
         '''
-        obj = meta.Session.query(cls).autoflush(autoflush)\
-              .filter_by(ldap_id=ldap_id).first()
+        obj = model.meta.Session.query(cls).autoflush(autoflush) \
+            .filter_by(ldap_id=ldap_id).first()
         return obj
 
     @classmethod
@@ -51,15 +54,13 @@ class LdapUser(domain_object.DomainObject):
         :returns: LdapUser object or None
 
         '''
-        obj = meta.Session.query(cls).autoflush(autoflush)\
-              .filter_by(user_id=user_id).first()
+        obj = model.meta.Session.query(cls).autoflush(autoflush) \
+            .filter_by(user_id=user_id).first()
         return obj
 
-meta.mapper(LdapUser, ldap_user_table,
-       properties={
-            u'user': orm.relation(user.User,
-                backref=orm.backref(u'ldap_user',
-                cascade=u'all, delete, delete-orphan'
-                ))
-            },
-       )
+
+model.meta.mapper(LdapUser, ldap_user_table, properties={
+    u'user': orm.relation(model.user.User,
+                          backref=orm.backref(u'ldap_user',
+                                              cascade=u'all, delete, delete-orphan'))
+    }, )

--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# This file is part of ckanext-ldap
+# Created by the Natural History Museum in London, UK
+
 import logging
 import pylons
 import ckan.plugins as p
@@ -14,14 +20,17 @@ log = logging.getLogger(__name__)
 
 
 class ConfigError(Exception):
+    ''' '''
     pass
 
 class LdapPlugin(p.SingletonPlugin):
-    """"LdapPlugin
-
+    '''"LdapPlugin
+    
     This plugin provides Ldap authentication by implementing the IAuthenticator
     interface.
-    """
+
+
+    '''
     p.implements(p.IAuthenticator)
     p.implements(p.IConfigurable)
     p.implements(p.IConfigurer)
@@ -30,137 +39,172 @@ class LdapPlugin(p.SingletonPlugin):
     p.implements(p.ITemplateHelpers, inherit=True)
 
     def update_config(self, config):
-        """Implement IConfiguer.update_config
-
+        '''Implement IConfiguer.update_config
+        
         Add our custom template to the list of templates so we can override the login form.
-        """
-        p.toolkit.add_template_directory(config, 'templates')
+
+        :param config: 
+
+        '''
+        p.toolkit.add_template_directory(config, u'templates')
 
     def before_map(self, map):
-        """Implements Iroutes.before_map
+        '''Implements Iroutes.before_map
+        
+        Add our custom login form handler
 
-        Add our custom login form handler"""
+        :param map: 
+
+        '''
         map.connect('/ldap_login_handler',
-                    controller='ckanext.ldap.controllers.user:UserController',
-                    action='login_handler')
+                    controller=u'ckanext.ldap.controllers.user:UserController',
+                    action=u'login_handler')
         return map
 
     def get_auth_functions(self):
-        """Implements IAuthFunctions.get_auth_functions"""
+        '''Implements IAuthFunctions.get_auth_functions'''
         return {
-            'user_update': user_update,
-            'user_create': user_create
+            u'user_update': user_update,
+            u'user_create': user_create
         }
 
     def configure(self, main_config):
-        """Implementation of IConfigurable.configure"""
+        '''Implementation of IConfigurable.configure
+
+        :param main_config: 
+
+        '''
         # Setup our models
         model_setup()
         # Our own config schema, defines required items, default values and transform functions
         schema = {
-            'ckanext.ldap.uri': {'required': True},
-            'ckanext.ldap.base_dn': {'required': True},
-            'ckanext.ldap.search.filter': {'required': True},
-            'ckanext.ldap.username': {'required': True},
-            'ckanext.ldap.email': {'required': True},
-            'ckanext.ldap.auth.dn': {},
-            'ckanext.ldap.auth.password': {'required_if': 'ckanext.ldap.auth.dn'},
-            'ckanext.ldap.auth.method': {'default': 'SIMPLE', 'validate': _allowed_auth_methods},
-            'ckanext.ldap.auth.mechanism': {'default': 'DIGEST-MD5', 'validate': _allowed_auth_mechanisms},
-            'ckanext.ldap.search.alt': {},
-            'ckanext.ldap.search.alt_msg': {'required_if': 'ckanext.ldap.search.alt'},
-            'ckanext.ldap.fullname': {},
-            'ckanext.ldap.organization.id': {},
-            'ckanext.ldap.organization.role': {'default': 'member', 'validate': _allowed_roles},
-            'ckanext.ldap.ckan_fallback': {'default': False, 'parse': p.toolkit.asbool},
-            'ckanext.ldap.prevent_edits': {'default': False, 'parse': p.toolkit.asbool},
-            'ckanext.ldap.migrate': {'default': False, 'parse': p.toolkit.asbool},
-            'ckanext.ldap.debug_level': {'default': 0, 'parse': p.toolkit.asint},
-            'ckanext.ldap.trace_level': {'default': 0, 'parse': p.toolkit.asint},
+            u'ckanext.ldap.uri': {u'required': True},
+            u'ckanext.ldap.base_dn': {u'required': True},
+            u'ckanext.ldap.search.filter': {u'required': True},
+            u'ckanext.ldap.username': {u'required': True},
+            u'ckanext.ldap.email': {u'required': True},
+            u'ckanext.ldap.auth.dn': {},
+            u'ckanext.ldap.auth.password': {u'required_if': u'ckanext.ldap.auth.dn'},
+            u'ckanext.ldap.auth.method': {u'default': u'SIMPLE', u'validate': _allowed_auth_methods},
+            u'ckanext.ldap.auth.mechanism': {u'default': u'DIGEST-MD5', u'validate': _allowed_auth_mechanisms},
+            u'ckanext.ldap.search.alt': {},
+            u'ckanext.ldap.search.alt_msg': {u'required_if': u'ckanext.ldap.search.alt'},
+            u'ckanext.ldap.fullname': {},
+            u'ckanext.ldap.organization.id': {},
+            u'ckanext.ldap.organization.role': {u'default': u'member', u'validate': _allowed_roles},
+            u'ckanext.ldap.ckan_fallback': {u'default': False, u'parse': p.toolkit.asbool},
+            u'ckanext.ldap.prevent_edits': {u'default': False, u'parse': p.toolkit.asbool},
+            u'ckanext.ldap.migrate': {u'default': False, u'parse': p.toolkit.asbool},
+            u'ckanext.ldap.debug_level': {u'default': 0, u'parse': p.toolkit.asint},
+            u'ckanext.ldap.trace_level': {u'default': 0, u'parse': p.toolkit.asint},
         }
         errors = []
         for i in schema:
             v = None
             if i in main_config:
                 v = main_config[i]
-            elif i.replace('ckanext.', '') in main_config:
-                log.warning('LDAP configuration options should be prefixed with \'ckanext.\'. ' +
-                            'Please update {0} to {1}'.format(i.replace('ckanext.', ''), i))
+            elif i.replace(u'ckanext.', u'') in main_config:
+                log.warning(u'LDAP configuration options should be prefixed with \'ckanext.\'. ' +
+                            u'Please update {0} to {1}'.format(i.replace(u'ckanext.', u''), i))
                 # Support ldap.* options for backwards compatibility
-                main_config[i] = main_config[i.replace('ckanext.', '')]
+                main_config[i] = main_config[i.replace(u'ckanext.', u'')]
                 v = main_config[i]
 
             if v:
-                if 'parse' in schema[i]:
-                    v = (schema[i]['parse'])(v)
+                if u'parse' in schema[i]:
+                    v = (schema[i][u'parse'])(v)
                 try:
-                    if 'validate' in schema[i]:
-                        (schema[i]['validate'])(v)
+                    if u'validate' in schema[i]:
+                        (schema[i][u'validate'])(v)
                     config[i] = v
                 except ConfigError as e:
                     errors.append(str(e))
-            elif schema[i].get('required', False):
-                errors.append('Configuration parameter {} is required'.format(i))
-            elif schema[i].get('required_if', False) and schema[i]['required_if'] in config:
-                errors.append('Configuration parameter {} is required when {} is presnt'.format(i,
-                    schema[i]['required_if']))
-            elif 'default' in schema[i]:
-                config[i] = schema[i]['default']
+            elif schema[i].get(u'required', False):
+                errors.append(u'Configuration parameter {} is required'.format(i))
+            elif schema[i].get(u'required_if', False) and schema[i][u'required_if'] in config:
+                errors.append(u'Configuration parameter {} is required when {} is presnt'.format(i,
+                    schema[i][u'required_if']))
+            elif u'default' in schema[i]:
+                config[i] = schema[i][u'default']
         if len(errors):
-            raise ConfigError("\n".join(errors))
+            raise ConfigError(u'\n'.join(errors))
         # make sure all the strings in the config are unicode formatted
         for key, value in config.iteritems():
             if isinstance(value, str):
-                config[key] = unicode(value, encoding='utf-8')
+                config[key] = unicode(value, encoding=u'utf-8')
 
     def login(self):
-        """Implementation of IAuthenticator.login
-
+        '''Implementation of IAuthenticator.login
+        
         We don't need to do anything here as we override the form & implement our own controller action
-        """
+
+
+        '''
         pass
 
     def identify(self):
-        """ Implementiation of IAuthenticator.identify
-
+        '''Implementiation of IAuthenticator.identify
+        
         Identify which user (if any) is logged in via this plugin
-        """
+
+
+        '''
         # FIXME: This breaks if the current user changes their own user name.
-        user = pylons.session.get('ckanext-ldap-user')
+        user = pylons.session.get(u'ckanext-ldap-user')
         if user:
             p.toolkit.c.user = user
 
     def logout(self):
-        """Implementation of IAuthenticator.logout"""
+        '''Implementation of IAuthenticator.logout'''
         self._delete_session_items()
 
     def abort(self, status_code, detail, headers, comment):
-        """Implementation of IAuthenticator.abort"""
+        '''Implementation of IAuthenticator.abort
+
+        :param status_code: 
+        :param detail: 
+        :param headers: 
+        :param comment: 
+
+        '''
         return status_code, detail, headers, comment
 
     def _delete_session_items(self):
-        """Delete user details stored in the session by this plugin"""
-        if 'ckanext-ldap-user' in pylons.session:
-            del pylons.session['ckanext-ldap-user']
+        '''Delete user details stored in the session by this plugin'''
+        if u'ckanext-ldap-user' in pylons.session:
+            del pylons.session[u'ckanext-ldap-user']
             pylons.session.save()
 
     def get_helpers(self):
+        ''' '''
         return {
-            'is_ldap_user': is_ldap_user
+            u'is_ldap_user': is_ldap_user
         }
 
 
 def _allowed_roles(v):
-    """Raise an exception if the value is not an allowed role"""
-    if v not in ['member', 'editor', 'admin']:
-        raise ConfigError('role must be one of "member", "editor" or "admin"')
+    '''
+
+    :param v: 
+
+    '''
+    if v not in [u'member', u'editor', u'admin']:
+        raise ConfigError(u'role must be one of "member", "editor" or "admin"')
 
 def _allowed_auth_methods(v):
-    """Raise an exception if the value is not an allowed authentication method"""
-    if v.upper() not in ['SIMPLE', 'SASL']:
-        raise ConfigError('Only SIMPLE and SASL authentication methods are supported')
+    '''
+
+    :param v: 
+
+    '''
+    if v.upper() not in [u'SIMPLE', u'SASL']:
+        raise ConfigError(u'Only SIMPLE and SASL authentication methods are supported')
 
 def _allowed_auth_mechanisms(v):
-    """Raise an exception if the value is not an allowed authentication mechanism"""
-    if v.upper() not in ['DIGEST-MD5',]:  # Only DIGEST-MD5 is supported when the auth method is SASL
-        raise ConfigError('Only DIGEST-MD5 is supported as an authentication mechanism')
+    '''
+
+    :param v: 
+
+    '''
+    if v.upper() not in [u'DIGEST-MD5',]:  # Only DIGEST-MD5 is supported when the auth method is SASL
+        raise ConfigError(u'Only DIGEST-MD5 is supported as an authentication mechanism')

--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -137,6 +137,10 @@ class LdapPlugin(SingletonPlugin):
                 u'default': 0,
                 u'parse': toolkit.asint
                 },
+            u'ckanext.ldap.use_first': {
+                u'default': False,
+                u'parse': toolkit.asbool
+                }
             }
         errors = []
         for i in schema:

--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -198,6 +198,9 @@ class LdapPlugin(SingletonPlugin):
         user = session.get(u'ckanext-ldap-user')
         if user:
             toolkit.c.user = user
+        else:
+            # add the 'user' attribute to the context to avoid issue #4247
+            toolkit.c.user = None
 
     def logout(self):
         '''Implementation of IAuthenticator.logout'''

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,25 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# This file is part of ckanext-ldap
+# Created by the Natural History Museum in London, UK
+
 from setuptools import setup, find_packages
 
-version = '0.1'
+version = u'0.1'
 
 setup(
-	name='ckanext-ldap',
+	name=u'ckanext-ldap',
 	version=version,
-	description="CKAN plugin to provide LDAP authentication",
-    url='https://github.com/NaturalHistoryMuseum/ckanext-ldap',
+	description=u'CKAN plugin to provide LDAP authentication',
+    url=u'https://github.com/NaturalHistoryMuseum/ckanext-ldap',
 	packages=find_packages(),
-	namespace_packages=['ckanext', 'ckanext.ldap'],
-	entry_points="""
+	namespace_packages=[u'ckanext', u'ckanext.ldap'],
+	entry_points=u'''
         [ckan.plugins]
             ldap = ckanext.ldap.plugin:LdapPlugin
         [paste.paster_command]
             ldap=ckanext.ldap.commands.ldap:LDAPCommand
-	""",
+	''',
     include_package_data=True,
 )


### PR DESCRIPTION
Have a situation with the ldap server in my group that returns multiple records, but only the first record is applicable (the others are empty). Added an option to override `ckanext.ldap.search.filter` to accept the first record when multiple records are found.