### PR TITLE
Tiny fix on old except syntax

### DIFF
--- a/ckanext/ldap/lib/search.py
+++ b/ckanext/ldap/lib/search.py
@@ -53,7 +53,7 @@ def find_ldap_user(login):
                 u'LDAP server credentials (ckanext.ldap.auth.dn and ckanext.ldap.auth.password) '
                 u'invalid')
             return None
-        except ldap.LDAPError, e:
+        except ldap.LDAPError as e:
             log.error(u'Fatal LDAP Error: {0}'.format(e))
             return None
 

--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -151,7 +151,10 @@ class LdapPlugin(SingletonPlugin):
 
             # make sure the config options are all unicode for LDAP
             if isinstance(toolkit.config.get(key, None), str):
-                toolkit.config[key] = str(toolkit.config.get(key))
+                try:
+                    toolkit.config[key] = unicode(toolkit.config.get(key))
+                except NameError:
+                    toolkit.config[key] = str(toolkit.config.get(key))
         if len(errors):
             raise ConfigError(u'\n'.join(errors))
 

--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -151,7 +151,7 @@ class LdapPlugin(SingletonPlugin):
 
             # make sure the config options are all unicode for LDAP
             if isinstance(toolkit.config.get(key, None), str):
-                toolkit.config[key] = unicode(toolkit.config.get(key))
+                toolkit.config[key] = str(toolkit.config.get(key))
         if len(errors):
             raise ConfigError(u'\n'.join(errors))
 


### PR DESCRIPTION
Just a couple of tiny fixes for an error in the logs in /etc/ckan/default/uwsgi.ERR, on a new CKAN 2.9.0 install from source, with Ubuntu 20.04 server. (Python 3.8.5)

One is a missing "as" in the exception syntax in lib/search.py; The other is that apparently "Python 3 renamed the unicode type to str, the old str type has been replaced by bytes." and you have one unicode left in plugin.py.

Without these fixes, CKAN fails to start with "Internal Server Error". 