### PR TITLE
hotfix for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,8 +2,7 @@ version: 2
 
 python:
   install:
-    - method: pip
-      path: .[docs]
+    - requirements: docs/requirements.txt
 
 mkdocs:
   configuration: mkdocs.yml

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs
+mkdocstrings[python]
+mkdocs-material
+mkdocs-gen-files
+mkdocs-section-index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,6 @@ test = [
     "pytest-cov>=2.7.1",
     "coveralls"
 ]
-docs = [
-    "mkdocs",
-    "mkdocstrings[python]",
-    "mkdocs-material",
-    "mkdocs-gen-files",
-    "mkdocs-section-index"
-]
 
 [project.urls]
 repository = "https://github.com/NaturalHistoryMuseum/ckanext-ldap"


### PR DESCRIPTION
Move docs requirements into separate file so they can be installed by readthedocs without installing main requirements.