### PR TITLE
Update test docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM naturalhistorymuseum/ckantest:0.2
+FROM naturalhistorymuseum/ckantest:latest
 
 # required by python-ldap
 RUN apt-get -q -y install libldap2-dev libsasl2-dev \


### PR DESCRIPTION
Use the "latest" tag for the test docker image instead of explicitly specifying a version number.