### PR TITLE
missing 'about' key added

### DIFF
--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -93,6 +93,7 @@ class LdapPlugin(SingletonPlugin):
             'ckanext.ldap.search.alt': {},
             'ckanext.ldap.search.alt_msg': {'required_if': 'ckanext.ldap.search.alt'},
             'ckanext.ldap.fullname': {},
+            'ckanext.ldap.about':{},
             'ckanext.ldap.organization.id': {},
             'ckanext.ldap.organization.role': {
                 'default': 'member',


### PR DESCRIPTION
the key is listed in the documentation and in the rest of the code, but is missing in the schema declaration.