### PR TITLE
Add support for CKAN 2.10.0+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 dist/
 .idea
 **/node_modules/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Tests](https://img.shields.io/github/actions/workflow/status/NaturalHistoryMuseum/ckanext-ldap/main.yml?style=flat-square)](https://github.com/NaturalHistoryMuseum/ckanext-ldap/actions/workflows/main.yml)
 [![Coveralls](https://img.shields.io/coveralls/github/NaturalHistoryMuseum/ckanext-ldap/main?style=flat-square)](https://coveralls.io/github/NaturalHistoryMuseum/ckanext-ldap)
-[![CKAN](https://img.shields.io/badge/ckan-2.9.7-orange.svg?style=flat-square)](https://github.com/ckan/ckan)
+[![CKAN](https://img.shields.io/badge/ckan-2.9.7+%20%7C%202.10-orange.svg?style=flat-square)](https://github.com/ckan/ckan)
 [![Python](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8-blue.svg?style=flat-square)](https://www.python.org/)
 [![Docs](https://img.shields.io/readthedocs/ckanext-ldap?style=flat-square)](https://ckanext-ldap.readthedocs.io)
 

--- a/ckanext/ldap/plugin.py
+++ b/ckanext/ldap/plugin.py
@@ -154,7 +154,14 @@ class LdapPlugin(SingletonPlugin):
 
     # IAuthenticator
     def logout(self):
+        # Delete session items managed by ckanext-ldap
         self._delete_session_items()
+
+        # In CKAN 2.10.0+, we also need to invoke the toolkit's
+        # logout_user() command to clean up anything remaining
+        # on the CKAN side.
+        if toolkit.check_ckan_version(min_version='2.10.0'):
+            toolkit.logout_user()
 
     # IAuthenticator
     def abort(self, status_code, detail, headers, comment):


### PR DESCRIPTION
## Overview

This PR adds support for CKAN 2.10.0+ It addresses #116 -- see the issue report for much more detailed information & background.

## Notes

### Compatibility

This code updates `ckanext-ldap` to work with _released_ versions of CKAN 2.10. It's worth nothing that alpha versions of CKAN -- those identified as `2.10.0a0` in the upstream CKAN code -- may or may not work, depending on whether or not that version contains the commit that merged ckan/ckan#6560.

If the alpha commit is from after that merge, then this plugin will work as expected.

If not (i.e., the end-user is using CKAN 2.10.0a0 at a commit from _before_ that PR was merged), then the user is functionally running CKAN 2.9.x in terms of authentication. The plugin will not work correctly, and to fix it, they would need to undo the changes from this PR by removing the `if toolkit.check_ckan_version()` blocks that this PR adds.

(As a note -- I logged ckan/ckan#7777 to hopefully improve this versioning situation in the future.)

I thought about putting notes about this in the code, but decided it was too deep in the weeds -- my thought is that if someone encounters issues this particular issue, they will either upgrade CKAN to a released 2.10 version, or find this PR and roll back the changes locally.

### Other changes

I updated the CKAN badge in the README to include 2.10, and emphasize that you support 2.9.7 and higher. Not sure if that's the approach you feel is best; figured I'd at least throw something out there to start with.

### Remember Me & CSRF not included

I opted not to implement "Remember Me". I'm not sure if this existed in 2.9, or if it's new to 2.10. The upstream `login()` code in [ckan/ckan v2.9.9](https://github.com/ckan/ckan/blob/ckan-2.9.9/ckan/views/user.py#L454) and [ckan/ckan v2.10.1](https://github.com/ckan/ckan/blob/ckan-2.10.1/ckan/views/user.py#L521) differs quite a bit (because of the migration to flask-login). If this is 2.10-only, we can probably do something similar to what CKAN does. Otherwise, we'll need to understand how CKAN 2.9 is doing it, and probably add some conditional logic.

Similarly, I opted not to try implementing the CSRF protection. After some quick reading, I still don't fully understand what it's about, so I don't feel confident enough to tackle that. I'm not really sure how to test it, since I'm not a front-end developer.

Regardless of all this, I think both of those features should be handled via separate issues/PR's, as they are not strictly necessary for 2.10 support.