### PR TITLE
Update docker command for test runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build images
-        run: docker-compose build
+        run: docker compose build
 
       - name: Run tests
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: docker-compose run -e COVERALLS_REPO_TOKEN latest bash /opt/scripts/run-tests.sh -c ckanext.ldap
+        run: docker compose run -e COVERALLS_REPO_TOKEN latest bash /opt/scripts/run-tests.sh -c ckanext.ldap
 
   test_next:
     runs-on: ubuntu-latest
@@ -28,8 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build images
-        run: docker-compose build
+        run: docker compose build
 
       - name: Run tests
-        run: docker-compose run next bash /opt/scripts/run-tests.sh -c ckanext.ldap
-
+        run: docker compose run next bash /opt/scripts/run-tests.sh -c ckanext.ldap

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ To run the tests can be run against ckan 2.9.x and 2.10.x on Python3:
 
 1. Build the required images:
    ```shell
-   docker-compose build
+   docker compose build
    ```
 
 2. Then run the tests.
@@ -189,10 +189,10 @@ To run the tests can be run against ckan 2.9.x and 2.10.x on Python3:
    you change the extension's dependencies.
    ```shell
    # run tests against ckan 2.9.x
-   docker-compose run latest
+   docker compose run latest
 
    # run tests against ckan 2.10.x
-   docker-compose run next
+   docker compose run next
    ```
 
 <!--testing-end-->


### PR DESCRIPTION
docker-compose is deprecated and tests were no longer running.