### PR TITLE
Test fixes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,27 +5,19 @@ from ckanext.ldap.model.ldap_user import ldap_user_table
 try:
     # 2.11 compatibility
     from ckan.model import ensure_engine
-
-    ensure_engine_available = True
 except ImportError:
-    ensure_engine_available = False
+
+    def ensure_engine():
+        return None
 
 
 @pytest.fixture
 def ensure_db_init():
     """
-    Initialises the database for the LDAP plugin. If the tables already exist then
-    nothing happens. Must be called after the main CKAN db init.
+    Initialises the database for the LDAP plugin.
 
-    :returns: True if the database was modified, False if not
+    If the tables already exist then nothing happens. Must be called after the main CKAN
+    db init.
     """
-    if ensure_engine_available:
-        engine = ensure_engine()
-        if not ldap_user_table.exists(engine):
-            ldap_user_table.create(engine)
-            return True
-    else:
-        if not ldap_user_table.exists():
-            ldap_user_table.create()
-            return True
-    return False
+    engine = ensure_engine()
+    ldap_user_table.create(engine, checkfirst=True)

--- a/tests/routes/test_helpers.py
+++ b/tests/routes/test_helpers.py
@@ -29,6 +29,7 @@ IS_CKAN_29_OR_LOWER = not IS_CKAN_210_OR_HIGHER
 
 @pytest.mark.skipif(IS_CKAN_210_OR_HIGHER, reason='requires CKAN 2.9 or lower')
 @pytest.mark.filterwarnings('ignore::sqlalchemy.exc.SADeprecationWarning')
+@pytest.mark.usefixtures('clean_db', 'ensure_db_init')
 class TestLoginSuccess29:
     # these tests are only run on CKAN 2.9
 
@@ -56,6 +57,7 @@ class TestLoginSuccess29:
 
 @pytest.mark.skipif(IS_CKAN_29_OR_LOWER, reason='requires CKAN 2.10 or higher')
 @pytest.mark.filterwarnings('ignore::sqlalchemy.exc.SADeprecationWarning')
+@pytest.mark.usefixtures('clean_db', 'ensure_db_init')
 class TestLoginSuccess210:
     # these tests are only run on CKAN 2.10
     @pytest.mark.usefixtures('with_request_context')


### PR DESCRIPTION
- shortens the db init fixture, which was unnecessarily long
- cleans the db before running the version-dependent tests, which fixes an issue where running tests on a fresh 2.11 image would fail due to missing columns